### PR TITLE
Skip Configurations that can't be resolved

### DIFF
--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -18,10 +18,18 @@ class ConfigurationReader {
 
     ConfigurationData read(Project project, Configuration configuration) {
         config = project.licenseReport
-        LOGGER.info("Processing configuration [$configuration], configuration will be resolved")
-        configuration.resolvedConfiguration // force configuration resolution
+
         ConfigurationData data = new ConfigurationData()
         data.name = configuration.name
+
+        if (!configuration.canBeResolved) {
+            LOGGER.info("Skipping configuration [$configuration] as it can't be resolved")
+            return data
+        }
+
+        LOGGER.info("Processing configuration [$configuration], configuration will be resolved")
+        configuration.resolvedConfiguration // force configuration resolution
+
         Set<ResolvedDependency> dependencies = new TreeSet<ResolvedDependency>(new ResolvedDependencyComparator())
         for (ResolvedDependency dependency : configuration.resolvedConfiguration.getFirstLevelModuleDependencies()) {
             collectDependencies(dependencies, dependency)

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -8,6 +8,8 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.specs.Spec
 
+import java.security.InvalidParameterException
+
 /**
  * todo: rewrite me in an idiomatic way
  */
@@ -26,6 +28,11 @@ class ProjectReader {
              boolean isSatisfiedBy(Configuration configuration) {
                 for (String configurationName : project.licenseReport.configurations) {
                     if (configuration.getName().equalsIgnoreCase(configurationName)) {
+                        if (!configuration.canBeResolved) {
+                            throw new InvalidParameterException("Project Reader: " +
+                                    "The specified configuration \"${configuration.name}\" can't be resolved. " +
+                                    "Try specifying a more specific configuration by adding flavor(s) and/or build type.")
+                        }
                         return true
                     }
                 }


### PR DESCRIPTION
With Android Studio 3 hitting the stable channels and suggesting every project to use the Gradle Plugin 3.0, with Gradle 4.1, it is now incentivized to use the new `implementation` and `api` configurations to specify dependencies, instead of the now deprecated `compile` one.
https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations

If you use the new configurations and configure the plugin like this:
```
licenseReport {
    // Adjust the configurations to use, e.g. for Android projects.
    configurations = ['compile']
}
```
No dependency will be reported.

If you try to specify `implementation` and/or `api`, you'd get errors like:
`Resolving configuration 'implementation' directly is not allowed`
Since those configurations and highly dependent on the build flavors.
https://github.com/jeremylong/dependency-check-gradle/issues/31
https://discuss.gradle.org/t/3-4-rc-1-3-3-resolving-configurations-may-be-disallowed-and-throw-illegalstateexception/21470

I found that specifying the configuration like:
```
licenseReport {
    configurations = ['{yourFlavorMix}ReleaseRuntimeClasspath'] // or releaseRuntimeClasspath if you don't use flavors
}
```
Works just like before with `compile`, as long as we check to not try to resolve configurations that can't be resolved.