### PR TITLE
#39 Added CSS for print, #40 fix older versions of gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `build.gradle` file:
 
 ```groovy
 plugins {
-  id 'com.github.jk1.dependency-license-report' version '0.4.0'
+  id 'com.github.jk1.dependency-license-report' version '0.4.1'
 }
 ```
 
@@ -32,7 +32,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'gradle.plugin.com.github.jk1:gradle-license-report:0.4.0'
+        classpath 'gradle.plugin.com.github.jk1:gradle-license-report:0.4.1'
     }
 }
 apply plugin: 'com.github.jk1.dependency-license-report'
@@ -172,7 +172,7 @@ repositories {
 }
 
 dependencies {
-    compile 'gradle.plugin.com.github.jk1:gradle-license-report:0.4.0'
+    compile 'gradle.plugin.com.github.jk1:gradle-license-report:0.4.1'
 }
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins{
 }
 
 group = "com.github.jk1"
-version = "0.4.0"
+version = "0.4.1"
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -22,7 +22,7 @@ class ConfigurationReader {
         ConfigurationData data = new ConfigurationData()
         data.name = configuration.name
 
-        if (!configuration.canBeResolved) {
+        if ( configuration.hasProperty("canBeResolved") && !configuration.canBeResolved) {
             LOGGER.info("Skipping configuration [$configuration] as it can't be resolved")
             return data
         }

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -27,7 +27,7 @@ class ProjectReader {
              boolean isSatisfiedBy(Configuration configuration) {
                 for (String configurationName : project.licenseReport.configurations) {
                     if (configuration.getName().equalsIgnoreCase(configurationName)) {
-                        if (!configuration.canBeResolved) {
+                        if (configuration.hasProperty("hasProperty") && !configuration.canBeResolved) {
                             throw new GradleException("Project Reader: " +
                                     "The specified configuration \"${configuration.name}\" can't be resolved. " +
                                     "Try specifying a more specific configuration by adding flavor(s) and/or build type.")

--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -49,6 +49,16 @@ class InventoryHtmlReportRenderer implements ReportRenderer {
 <head>
 <title>Dependency License Report for ${name}</title>
 <style>
+    @media print {
+        .inventory {
+            display: none;
+        }
+
+        .content {
+            position: static !important;
+        }
+    }
+
     html, body, section {
       height: 100%;
     }


### PR DESCRIPTION
#39: Added CSS rules for print so users can easily print out pages for use in docs as exhibits.
#40: Added some code to allow recent changes to be portable to older versions of gradle.