### PR TITLE
Add normalizer to adapt license information before rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .gradle
 build
+out

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins{
     id 'groovy'
     id 'maven-publish'
     id 'com.gradle.plugin-publish' version '0.9.9'
+    id 'java-gradle-plugin'
 }
 
 group = "com.github.jk1"
@@ -23,7 +24,6 @@ dependencies {
         exclude group: 'org.codehaus.groovy'
     }
 }
-
 
 task('sourcesJar', type: Jar, dependsOn: classes) {
     classifier = 'sources'
@@ -64,4 +64,8 @@ pluginBundle {
             displayName = 'Gradle dependency license report plugin'
         }
     }
+}
+
+gradlePlugin {
+    testSourceSets sourceSets.test
 }

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -1,0 +1,86 @@
+package com.github.jk1.license.filter
+
+import com.github.jk1.license.License
+import com.github.jk1.license.ModuleData
+import com.github.jk1.license.ProjectData
+import groovy.json.JsonSlurper
+
+
+class LicenseBundleNormalizer implements DependencyFilter {
+    LicenseBundleNormalizerConfig normalizerConfig
+    Map<String, NormalizerLicenseBundle> bundleMap
+
+    LicenseBundleNormalizer(String bundlePath = null) {
+        InputStream inputStream
+        if (bundlePath == null) {
+            inputStream = getClass().getResourceAsStream("/default-license-normalizer-bundle.json")
+        } else {
+            inputStream = new FileInputStream(new File(bundlePath))
+        }
+
+        normalizerConfig = toConfig(new JsonSlurper().parse(inputStream))
+
+        bundleMap = normalizerConfig.bundles.collectEntries {
+            [it.bundleName, it]
+        }
+    }
+
+    @Override
+    ProjectData filter(ProjectData data) {
+        data.allDependencies.forEach { normalizeDependency(it) }
+
+        return data
+    }
+
+    private def normalizeDependency(ModuleData dependency) {
+        dependency.poms
+                .collect { it.licenses }.flatten()
+                .forEach { normalizeLicense(it) }
+    }
+
+    private def normalizeLicense(License license) {
+        def bundle = findMatchingBundleForName(license.name)
+        if (bundle == null) bundle = findMatchingBundleForUrl(license.url)
+        if (bundle == null) return
+        applyBundleToLicense(bundle, license)
+    }
+
+    private def findMatchingBundleForName(String name) {
+        def transformToBundleName = normalizerConfig.transformationRules
+                .find { it.licenseNamePattern  && name ==~ it.licenseNamePattern }?.bundleName
+        return bundleMap[transformToBundleName]
+    }
+    private def findMatchingBundleForUrl(String url) {
+        def transformToBundleName = normalizerConfig.transformationRules
+                .find { it.licenseUrlPattern && url ==~ it.licenseUrlPattern }?.bundleName
+        return bundleMap[transformToBundleName]
+    }
+
+    private def applyBundleToLicense(NormalizerLicenseBundle bundle, License license) {
+        license.name = bundle.licenseName
+        license.url = bundle.licenseUrl
+    }
+
+    private def toConfig(Object slurpResult) {
+        def config = new LicenseBundleNormalizerConfig()
+        config.bundles = slurpResult.bundles.collect { new NormalizerLicenseBundle(it) }
+        config.transformationRules = slurpResult.transformationRules.collect { new NormalizerTransformationRule(it) }
+        config
+    }
+
+    class LicenseBundleNormalizerConfig {
+        List<NormalizerLicenseBundle> bundles
+        List<NormalizerTransformationRule> transformationRules
+    }
+    class NormalizerLicenseBundle {
+        String bundleName
+        String licenseName
+        String licenseUrl
+    }
+    class NormalizerTransformationRule {
+        String licenseNamePattern
+        String licenseUrlPattern
+        String bundleName
+    }
+}
+

--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -1,0 +1,25 @@
+{
+  "bundles" : [
+    { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-1.1" },
+    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "cddl1", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0", "licenseUrl" : "http://opensource.org/licenses/CDDL-1.0" },
+    { "bundleName" : "gpl1", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 1", "licenseUrl" : "https://www.gnu.org/licenses/gpl-1.0" },
+    { "bundleName" : "gpl2", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 2", "licenseUrl" : "https://www.gnu.org/licenses/gpl-2.0" },
+    { "bundleName" : "gpl3", "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/gpl-3.0" },
+    { "bundleName" : "lgpl2.1", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1" },
+    { "bundleName" : "lgpl3", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0" },
+    { "bundleName" : "mit", "licenseName" : "MIT License", "licenseUrl" : "https://opensource.org/licenses/MIT" },
+    { "bundleName" : "mpl2", "licenseName" : "Mozilla Public License, Version 2.0", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/2.0" },
+    { "bundleName" : "epl1", "licenseName" : "Eclipse Public License - v 1.0", "licenseUrl" : "http://www.eclipse.org/legal/epl-v10.html" },
+    { "bundleName" : "epl2", "licenseName" : "Eclipse Public License - v 2.0", "licenseUrl" : "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt" },
+    { "bundleName" : "cc0", "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "http://repository.jboss.org/licenses/cc0-1.0.txt" }
+  ],
+  "transformationRules" : [
+    { "bundleName" : "apache2", "licenseNamePattern" : ".*The Apache Software License, Version 2.0.*" },
+    { "bundleName" : "apache2", "licenseNamePattern" : "Apache 2.*" },
+    { "bundleName" : "apache2", "licenseNamePattern" : "ASL 2.0" },
+    { "bundleName" : "apache2", "licenseUrlPattern" : ".*www.apache.org/licenses/LICENSE-2.0.*" },
+    { "bundleName" : "lgpl2.1", "licenseUrlPattern" : ".*www.gnu.org/licenses/old-licenses/lgpl-2.1.html" },
+    { "bundleName" : "mit", "licenseUrlPattern" : ".*www.opensource.org/licenses/mit-license.php" }
+  ]
+}

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -1,0 +1,213 @@
+package com.github.jk1.license.filter
+
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Ignore
+import spock.lang.Specification
+
+class LicenseBundleNormalizerSpec extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+    File normalizerFile
+
+    File licenseResultJsonFile
+    def jsonSlurper = new JsonSlurper()
+
+    def setup() {
+        testProjectDir.create()
+        licenseResultJsonFile = new File(testProjectDir.root, "/build/licenses/index.json")
+
+        buildFile = testProjectDir.newFile('build.gradle')
+        normalizerFile = testProjectDir.newFile('test-normalizer-config.json')
+
+        buildFile << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+            }
+            configurations {
+                forTesting
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.filter.*
+            import com.github.jk1.license.render.*
+            licenseReport {
+                outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
+                filters = new LicenseBundleNormalizer("$normalizerFile.absolutePath")
+                renderer = new JsonReportRenderer()
+                configurations = ['forTesting']
+            }
+        """
+
+        normalizerFile << """
+            {
+              "bundles" : [
+                { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-1.1" },
+                { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-2.0" },
+                { "bundleName" : "cddl1", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0", "licenseUrl" : "http://opensource.org/licenses/CDDL-1.0" }
+              ],
+        """
+    }
+
+    def "normalizes dependencies by configured license name"() {
+        buildFile << """
+            dependencies {
+                forTesting "org.jetbrains:annotations:13.0"     // license-name: "The Apache Software License, Version 2.0"
+                forTesting "io.netty:netty-common:4.1.17.Final" // license-name: "Apache License, Version 2.0"
+            }
+        """
+        normalizerFile << """
+              "transformationRules" : [
+                { "bundleName" : "apache2", "licenseNamePattern" : ".*The Apache Software License, Version 2.0.*" }
+              ]
+            }
+        """
+
+        when:
+        def runResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('generateLicenseReport')
+                .withPluginClasspath()
+                .build()
+
+        def result = jsonSlurper.parse(licenseResultJsonFile)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        result.dependencies.size() == 2
+        result.dependencies*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
+        result.dependencies*.moduleLicenseUrl.toSet() == ["http://www.apache.org/licenses/LICENSE-2.0"].toSet()
+    }
+
+    def "normalizes dependencies by configured license url"() {
+        buildFile << """
+            dependencies {
+                forTesting "org.jetbrains:annotations:13.0"     // license-url: "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                forTesting "io.netty:netty-common:4.1.17.Final" // license-url: "http://www.apache.org/licenses/LICENSE-2.0"
+            }
+        """
+        normalizerFile << """
+              "transformationRules" : [
+                { "bundleName" : "apache2", "licenseUrlPattern" : ".*http://www.apache.org/licenses/LICENSE-2.0.txt.*" }
+              ]
+            }
+        """
+
+        when:
+        def runResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('generateLicenseReport')
+                .withPluginClasspath()
+                .build()
+
+        def result = jsonSlurper.parse(licenseResultJsonFile)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        result.dependencies.size() == 2
+        result.dependencies*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
+        result.dependencies*.moduleLicenseUrl.toSet() == ["http://www.apache.org/licenses/LICENSE-2.0"].toSet()
+    }
+
+    def "an error is raised when a normalizer file is specified but not available"() {
+        normalizerFile.delete()
+
+        when:
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('generateLicenseReport', '--stacktrace')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        thrown(Exception)
+    }
+
+    def "default filter file is used when nothing else specified"() {
+        buildFile.setText("") // clear the file first
+        buildFile << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+            }
+            configurations {
+                forTesting
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.filter.*
+            import com.github.jk1.license.render.*
+            licenseReport {
+                outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
+                filters = new LicenseBundleNormalizer()
+                renderer = new JsonReportRenderer()
+                configurations = ['forTesting']
+            }
+            dependencies {
+                forTesting "org.jetbrains:annotations:13.0"     // license-url: "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                forTesting "io.netty:netty-common:4.1.17.Final" // license-url: "http://www.apache.org/licenses/LICENSE-2.0"
+            }
+        """
+
+        when:
+        def runResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('generateLicenseReport', '--stacktrace')
+                .withPluginClasspath()
+                .build()
+
+        def result = jsonSlurper.parse(licenseResultJsonFile)
+        println(licenseResultJsonFile.text)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        result.dependencies*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
+        result.dependencies*.moduleLicenseUrl.toSet() == ["http://www.apache.org/licenses/LICENSE-2.0"].toSet()
+    }
+
+    @Ignore("add support for licence-text")
+    def "normalizes dependencies by configured license text"() {
+        buildFile << """
+            dependencies {
+                forTesting "joda-time:joda-time:2.9.9" // license-name: Apache 2
+            }
+        """
+        normalizerFile << """
+              "transformationRules" : [
+                { "bundleName" : "apache2", "licenseFileContentPattern" : ".*Apache License, Version 2.0.*" }
+              ]
+            }
+        """
+
+        when:
+        def runResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('generateLicenseReport')
+                .withPluginClasspath()
+                .build()
+
+        def result = jsonSlurper.parse(licenseResultJsonFile)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        result.dependencies.size() == 1
+        result.dependencies*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
+        result.dependencies*.moduleLicenseUrl.toSet() == ["http://www.apache.org/licenses/LICENSE-2.0"].toSet()
+    }
+
+    @Ignore("Think about multiple licenses of a file")
+    def "normalizes combined licenses without losing information of one of the single licenses"() {
+        // TODO
+        // e.g. javax.annotation:javax.annotation-api   CDDL + GPL
+    }
+}


### PR DESCRIPTION
    Often it happens that the same license in two libraries with slightly different name exists.
    In the rendered outout, this results in to lines what is annoying. This normalisation allows
    to define rules to unify lines according on the license name or url.