### PR TITLE
JsonReportRenderer cleanup: use of JsonBuilder, trim values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins{
 }
 
 group = "com.github.jk1"
-version = "0.5.1"
+version = "0.5.2"
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6


### PR DESCRIPTION
First off, great plugin! Thanks for sharing.

During evaluation I realised there are some cases in which invalid JSON is produced, eg: an entry value is parsed as a multi line String. While fixing that issue I figured it would be nice to switch to the proprietary JsonBuilder implementation to guarantee a valid JSON output.
The newly produced output is in terms of content identical to before, the order of entries differs slightly.
I intended to write thorough unit tests, but the extensive Mocking required lead me to simply test it manually.
I also increased the version to 0.5.2.