### PR TITLE
Support multi-license json rendering & consider manifest for normalisation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[gradlew.bat]
+end_of_line = crlf

--- a/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
@@ -61,7 +61,7 @@ class CsvReportRenderer extends SingleInfoReportRenderer {
     }
 
     void renderDependency(File output, LicenseReportPlugin.LicenseReportExtension config, ModuleData data) {
-        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = moduleLicenseInfo(config, data)
+        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(config, data)
 
         String artifact = "${data.group}:${data.name}:${data.version}"
         output << "${quote(artifact)}$separator${quote(moduleUrl)}$separator${quote(moduleLicense)}$separator${quote(moduleLicenseUrl)}$separator$nl"

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -1,0 +1,88 @@
+package com.github.jk1.license.render
+
+import com.github.jk1.license.License
+import com.github.jk1.license.LicenseReportPlugin
+import com.github.jk1.license.ModuleData
+
+class LicenseDataCollector {
+
+    protected static List<String> singleModuleLicenseInfo(LicenseReportPlugin.LicenseReportExtension config, ModuleData data) {
+        def info = multiModuleLicenseInfo(config, data, false)
+        def moduleUrl = info.moduleUrls?.last()
+        def license = info.licenses?.last()
+        def moduleLicense = license?.name
+        def moduleLicenseUrl = license?.url
+
+        [moduleUrl, moduleLicense, moduleLicenseUrl]
+    }
+
+    protected static MultiLicenseInfo multiModuleLicenseInfo(
+        LicenseReportPlugin.LicenseReportExtension config, ModuleData data, boolean alwaysCheckLicenseFiles = true) {
+        MultiLicenseInfo info = new MultiLicenseInfo()
+
+        data.manifests.each {
+            if (it.url) {
+                info.moduleUrls << it.url
+            }
+            if (it.license) {
+                if (isValidUrl(it.license)) {
+                    info.licenses << new License(url: it.license)
+                } else {
+                    info.licenses << new License(name: it.license)
+                }
+            }
+        }
+        data.poms.each {
+            if (it.projectUrl) {
+                info.moduleUrls << it.projectUrl
+            }
+            if (it.licenses) {
+                info.licenses.addAll(it.licenses)
+            }
+        }
+
+        // Check just here for backward compatibility reason of "simple" json-renderer.
+        // think about removing this at all and risk that the simple-renderers gets a different result in case
+        // several licenses are available
+        if (info.licenses.isEmpty() || !info.licenses.last().url || alwaysCheckLicenseFiles) {
+            data.licenseFiles.each {
+                it.files.each {
+                    String moduleLicense = null
+                    String moduleLicenseUrl = null
+                    def text = new File(config.outputDir, it).text
+                    if (text.contains('Apache License, Version 2.0')) {
+                        moduleLicense = 'Apache License, Version 2.0'
+                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                    if (text.contains('Apache Software License, Version 1.1')) {
+                        moduleLicense = 'Apache Software License, Version 1.1'
+                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-1.1'
+                    }
+                    if (text.contains('CDDL')) {
+                        moduleLicense = 'COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0'
+                        moduleLicenseUrl = 'http://opensource.org/licenses/CDDL-1.0'
+                    }
+
+                    if (moduleLicense || moduleLicenseUrl) {
+                        info.licenses << new License(name: moduleLicense, url: moduleLicenseUrl)
+                    }
+                }
+            }
+        }
+        info
+    }
+
+    private static boolean isValidUrl(String url) {
+        try {
+            new URI(url)
+            return true
+        } catch (URISyntaxException e) {
+            return false
+        }
+    }
+
+    protected static class MultiLicenseInfo {
+        List<String> moduleUrls = new ArrayList<>()
+        List<License> licenses = new ArrayList<>()
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/render/SingleInfoReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SingleInfoReportRenderer.groovy
@@ -9,57 +9,11 @@ import static com.github.jk1.license.LicenseReportPlugin.LicenseReportExtension
  */
 abstract class SingleInfoReportRenderer implements ReportRenderer {
 
+    /**
+     * @deprecated Use {@link LicenseDataCollector#singleModuleLicenseInfo} instead
+     */
+    @Deprecated
     protected List<String> moduleLicenseInfo(LicenseReportExtension config, ModuleData data) {
-        String moduleUrl = null
-        String moduleLicense = null
-        String moduleLicenseUrl = null
-
-        data.manifests.each {
-            if (it.url) {
-                moduleUrl = it.url
-            }
-            if (it.license) {
-                if (it.license.startsWith('http')) {
-                    moduleLicenseUrl = it.license
-                }
-                moduleLicense = it.license
-
-            }
-        }
-        data.poms.each {
-            if (it.projectUrl) {
-                moduleUrl = it.projectUrl
-            }
-            if (it.licenses) {
-                it.licenses.each {
-                    if (it.name) {
-                        moduleLicense = it.name
-                    }
-                    if (it.url && it.url.startsWith('http')) {
-                        moduleLicenseUrl = it.url
-                    }
-                }
-            }
-        }
-        if (!moduleLicenseUrl) {
-            data.licenseFiles.each {
-                it.files.each {
-                    def text = new File(config.outputDir, it).text
-                    if (text.contains('Apache License, Version 2.0')) {
-                        moduleLicense = 'Apache License, Version 2.0'
-                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'
-                    }
-                    if (text.contains('Apache Software License, Version 1.1')) {
-                        moduleLicense = 'Apache Software License, Version 1.1'
-                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-1.1'
-                    }
-                    if (text.contains('CDDL')) {
-                        moduleLicense = 'COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0'
-                        moduleLicenseUrl = 'http://opensource.org/licenses/CDDL-1.0'
-                    }
-                }
-            }
-        }
-        [moduleUrl, moduleLicense, moduleLicenseUrl]
+        return LicenseDataCollector.singleModuleLicenseInfo(config, data)
     }
 }

--- a/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
@@ -72,7 +72,7 @@ class XmlReportRenderer extends SingleInfoReportRenderer {
     private void printDependency(ModuleData data) {
         def moduleName = "${data.group}:${data.name}"
         def moduleVersion = data.version
-        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = moduleLicenseInfo(config, data)
+        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(config, data)
 
         output << "<tr>\n"
         if (moduleUrl) {

--- a/src/test/groovy/com/github/jk1/license/ProjectDataFixture.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectDataFixture.groovy
@@ -1,0 +1,181 @@
+package com.github.jk1.license
+
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+
+class ProjectDataFixture {
+    private static Project project = null
+    static def GRADLE_PROJECT() {
+        if (project == null) {
+            project = ProjectBuilder.builder().withName("my-project").build()
+            project.pluginManager.apply 'com.github.jk1.dependency-license-report'
+        }
+        project
+    }
+
+    static PomDeveloper POM_DEV_JODA() {
+        new PomDeveloper(name: "joda", email: "joda@star.wars", url: "http://joda")
+    }
+    static PomDeveloper POM_DEV_LUKE() {
+        new PomDeveloper(name: "luke", email: "luke@star.wars", url: "http://luke")
+    }
+    static License APACHE2_LICENSE() {
+        new License(
+            name: "Apache License, Version 2.0",
+            url: "https://www.apache.org/licenses/LICENSE-2.0",
+            distribution: "repo",
+            comments: "A business-friendly OSS license"
+        )
+    }
+    static License MIT_LICENSE() {
+        new License(
+            name: "MIT License",
+            url: "https://opensource.org/licenses/MIT",
+            distribution: "repo",
+            comments: "A short and simple permissive license"
+        )
+    }
+    static License LGPL_LICENSE() {
+        new License(
+            name: "GNU LESSER GENERAL PUBLIC LICENSE, Version 3",
+            url: "https://www.gnu.org/licenses/lgpl-3.0",
+            distribution: "repo",
+            comments: "A weak copyleft license"
+        )
+    }
+
+    static ManifestData MANIFEST_APACHE2_BY_NAME() {
+        new ManifestData(
+            name: "dummy-mani1-name",
+            version: "dummy-mani1-version",
+            description: "dummy-mani1-desc",
+            vendor: "dummy-mani1-vendor",
+            license: "Apache 2.0",
+            url: "http://dummy-mani1-url")
+    }
+    static ManifestData MANIFEST_APACHE2_BY_URL() {
+        new ManifestData(
+            name: "dummy-mani2-name",
+            version: "dummy-mani2-version",
+            description: "dummy-mani2-desc",
+            vendor: "dummy-mani2-vendor",
+            license: "http://www.apache.org/licenses/LICENSE-2.0.txt",
+            url: "http://dummy-mani2-url"
+        )
+    }
+    static ManifestData MANIFEST_MIT_BY_NAME() {
+        new ManifestData(
+            name: "dummy-mani3-name",
+            version: "dummy-mani3-version",
+            description: "dummy-mani3-desc",
+            vendor: "dummy-mani3-vendor",
+            license: "The MIT License",
+            url: "http://dummy-mani3-url"
+        )
+    }
+    static PomData POM_APACHE2() {
+        new PomData(
+            name: "dummy-pom2-name",
+            description: "dummy-pom2-description",
+            projectUrl: "http://dummy-pom2-project-url",
+            inceptionYear: "dummy-pom2-inception-year",
+            organization: new PomOrganization(
+                name: "dummy-pom2-org-name", url: "http://dummy-pom2-org-url"
+            ),
+            licenses: [APACHE2_LICENSE()],
+            developers: [POM_DEV_JODA()]
+        )
+    }
+    static PomData POM_APACHE2_MIT() {
+        new PomData(
+            name: "dummy-pom1-name",
+            description: "dummy-pom1-description",
+            projectUrl: "http://dummy-pom1-project-url",
+            inceptionYear: "dummy-pom1-inception-year",
+            organization: new PomOrganization(
+                name: "dummy-pom1-org-name", url: "http://dummy-pom1-org-url"
+            ),
+            licenses: [APACHE2_LICENSE(), MIT_LICENSE()],
+            developers: [POM_DEV_JODA(), POM_DEV_LUKE()]
+        )
+    }
+    static PomData POM_APACHT2_LGPL() {
+        new PomData(
+            name: "foo-parent-pom-name",
+            description: "foo-parent-pom-description",
+            projectUrl: "http://foo-parent-pom-project-url",
+            inceptionYear: "foo-parent-pom-inception-year",
+            organization: new PomOrganization(
+                name: "foo-pom-org-name", url: "http://foo-pom-org-url"
+            ),
+            licenses: [APACHE2_LICENSE(), LGPL_LICENSE()],
+            developers: [POM_DEV_JODA()]
+        )
+    }
+
+    static LicenseFileData LICENSE_FILE_APACHE2() {
+        new LicenseFileData(
+            files: ["apache2-license.txt"]
+        )
+    }
+
+    static def PROJECT_DATA_TWO_MODULES_AND_IMPORTED_MODULES() {
+        new ProjectData(
+            project: GRADLE_PROJECT(),
+            configurations: [
+                new ConfigurationData(
+                    name: "runtime",
+                    dependencies: [
+                        moduleDataWith(
+                            poms: [POM_APACHE2()],
+                            licenseFiles: [LICENSE_FILE_APACHE2()],
+                            manifests: [MANIFEST_APACHE2_BY_NAME()]),
+                        moduleDataWith(
+                            poms: [POM_APACHE2(), POM_APACHE2_MIT(), POM_APACHE2_MIT()],
+                            licenseFiles: [LICENSE_FILE_APACHE2()],
+                            manifests: [MANIFEST_APACHE2_BY_NAME()])
+                    ]
+                )
+            ],
+            importedModules: [
+                new ImportedModuleBundle(
+                    name: "foo-module-bundle-name",
+                    modules: [
+                        new ImportedModuleData(
+                            name: "foo-module-data-name",
+                            version: "foo-module-data-version",
+                            projectUrl: "http://foo-module-data-url",
+                            license: "foo-module-data-license",
+                            licenseUrl: "http://foo-module-data-license-url"
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+
+    static ProjectData projectDataWith(Map map = [poms: [], licenseFiles: [], manifests: []])
+    {
+        return new ProjectData(
+            project: GRADLE_PROJECT(),
+            configurations: [
+                new ConfigurationData(
+                    name: "runtime",
+                    dependencies: [
+                        moduleDataWith(map)
+                    ]
+                )
+            ]
+        )
+    }
+
+    static ModuleData moduleDataWith(Map map = [poms: [], licenseFiles: [], manifests: []])
+    {
+        return new ModuleData(
+            group: "dummy1-group", name: "dummy1-name", version: "0.0.1",
+            manifests: map.manifests ?: [],
+            licenseFiles: map.licenseFiles ?: [],
+            poms: map.poms ?: []
+        )
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
@@ -1,0 +1,147 @@
+package com.github.jk1.license.render
+
+import com.github.jk1.license.LicenseReportPlugin
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import static com.github.jk1.license.ProjectDataFixture.*
+
+class JsonReportRendererSpec extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File outputJson
+
+    def setup() {
+        testProjectDir.create()
+        outputJson = new File(testProjectDir.root, "index.json")
+        outputJson.delete()
+
+        LicenseReportPlugin.LicenseReportExtension extension = GRADLE_PROJECT().licenseReport
+        extension.outputDir = testProjectDir.root
+
+        // copy apache2 license file
+        def apache2LicenseFile = new File(getClass().getResource('/apache2-license.txt').toURI())
+        new File(testProjectDir.root, "apache2-license.txt") << apache2LicenseFile.text
+    }
+
+    def "writes a one-license-per-module json"() {
+        def jsonRenderer = new JsonReportRenderer()
+
+        when:
+        jsonRenderer.render(PROJECT_DATA_TWO_MODULES_AND_IMPORTED_MODULES())
+
+        then:
+        outputJson.exists()
+        outputJson.text == """{
+    "dependencies": [
+        {
+            "moduleName": "dummy1-group:dummy1-name",
+            "moduleUrl": "http://dummy-pom1-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "MIT License",
+            "moduleLicenseUrl": "https://opensource.org/licenses/MIT"
+        },
+        {
+            "moduleName": "dummy1-group:dummy1-name",
+            "moduleUrl": "http://dummy-pom2-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "Apache License, Version 2.0",
+            "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ],
+    "importedModules": [
+        {
+            "moduleName": "foo-module-bundle-name",
+            "dependencies": {
+                "moduleName": "foo-module-data-name",
+                "moduleUrl": "http://foo-module-data-url",
+                "moduleVersion": "foo-module-data-version",
+                "moduleLicense": "foo-module-data-license",
+                "moduleLicenseUrl": "http://foo-module-data-license-url"
+            }
+        }
+    ]
+}"""
+    }
+
+    def "writes a multi-license-per-module json"() {
+        def jsonRenderer = new JsonReportRenderer(
+            onlyOneLicensePerModule: false
+        )
+
+        when:
+        jsonRenderer.render(PROJECT_DATA_TWO_MODULES_AND_IMPORTED_MODULES())
+
+        then:
+        outputJson.exists()
+        outputJson.text == """{
+    "dependencies": [
+        {
+            "moduleName": "dummy1-group:dummy1-name",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-mani1-url",
+                "http://dummy-pom2-project-url",
+                "http://dummy-pom1-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache 2.0",
+                    "moduleLicenseUrl": null
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                },
+                {
+                    "moduleLicense": "MIT License",
+                    "moduleLicenseUrl": "https://opensource.org/licenses/MIT"
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "dummy1-group:dummy1-name",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-mani1-url",
+                "http://dummy-pom2-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache 2.0",
+                    "moduleLicenseUrl": null
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        }
+    ],
+    "importedModules": [
+        {
+            "moduleName": "foo-module-bundle-name",
+            "dependencies": {
+                "moduleName": "foo-module-data-name",
+                "moduleUrl": "http://foo-module-data-url",
+                "moduleVersion": "foo-module-data-version",
+                "moduleLicense": "foo-module-data-license",
+                "moduleLicenseUrl": "http://foo-module-data-license-url"
+            }
+        }
+    ]
+}"""
+    }
+}

--- a/src/test/resources/apache2-license.txt
+++ b/src/test/resources/apache2-license.txt
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
The existing json-renderer supports noly one single license per module, even if
a module has several licenses. Now, this can be configured, if the renderer
should run in the classical one-license mode or if it should render all the available
licenses for each module.

```
renderer = JsonReportRenderer()   // the single license renderer
renderer = JsonReportRenderer(onlyOneLicensePerModule: false)   // the multi-license renderer
```

I unified both variants in one `class` and tried to keep backward compatibility as good as possible. There are some circumstances, when a JAR-File has some ugly license handling and also some wrong licenses inside, that compatibility might break (e.g. `licenseName` and `licenseUrl` are different with this version than with the old one then)
