### PR TITLE
WIP: Fix duplicate licenses problem

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -28,7 +28,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
     @Override
     ProjectData filter(ProjectData data) {
-        data.allDependencies.forEach { normalizeDependency(it) }
+        data.configurations*.dependencies.flatten().forEach { normalizeDependency(it) }
         return data
     }
 


### PR DESCRIPTION
When a dependency is used in two configuration, the ProjectData#allDependencies
gets a set of them. This set hides duplicate dependencies. When now one of them
is normalized, the set not longer can identify them as the same what leads to
the problem, that the renderer then get a normalized and a unnormalized dep.
Instead of iterating over the #allDependencies, the configurations itself are
used, which normalizes then both dependencies instead of just one.