### PR TITLE
Document input format for XmlReportImporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,35 @@ licenseReport {
 }
 ```
 
+The expected input format for `XmlReportImporter` is as follows:
+
+```
+<topic>
+  <chunk>
+    <chapter title="Some of my favorite libraries">
+      <table>
+        <tr>
+          <!-- every non-empty chapter must have a title row, which is stripped>
+          <th>Name</th>
+          <th>Version</th>
+          <th>License</th>
+        </tr>
+        <tr>
+          <td><a href="https://url.of.project/homepage">Name of library</a></td>
+          <td>1.2.3</td>
+          <td><a href="http://url.of.project/license">Name of license</a></td>
+        </tr>
+        <!-- more libraries here...>
+      </table>
+    </chapter>
+    <!-- more chapters here...>
+  </chunk>
+  <!-- more chunks here...>
+</topic>
+```
+
+If there is only one chapter, the outer `topic` and `chunk` tags may be omitted.
+
 ## Filters
 Dependency filters transform discovered dependency data before rendering. 
 This may include sorting, reordering, data substitution. 

--- a/src/main/groovy/com/github/jk1/license/importer/XmlReportImporter.groovy
+++ b/src/main/groovy/com/github/jk1/license/importer/XmlReportImporter.groovy
@@ -30,7 +30,7 @@ class XmlReportImporter implements DependencyDataImporter {
             def root = createParser().parse(externalReport.call())
             if ("topic".equals(root.name())) {
                 bundles.addAll(parseTopic(root))
-            } else if ("chapter") {
+            } else if ("chapter".equals(root.name())) {
                 bundles.add(parseChapter(root))
             } else {
                 throw new GradleException("Dependency data importer: don't know how to parse ${root.name()} root tag")


### PR DESCRIPTION
I couldn't work the expected format out from the documentation and had to reverse-engineer it from the parsing code; this PR documents the format so nobody else has to do that.

Also fixes a bug where the outermost tag could be anything and it would be treated as if it were `chapter`.