### PR TITLE
Allow registering multiple renderers with array syntax

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
@@ -19,7 +19,7 @@ class LicenseReportPlugin implements Plugin<Project> {
     static class LicenseReportExtension {
 
         String outputDir
-        ReportRenderer renderer
+        ReportRenderer[] renderers
         DependencyDataImporter[] importers
         DependencyFilter[] filters
         String[] configurations
@@ -28,12 +28,31 @@ class LicenseReportPlugin implements Plugin<Project> {
 
         LicenseReportExtension(Project project) {
             outputDir = "${project.buildDir}/reports/dependency-license"
-            renderer = new SimpleHtmlReportRenderer()
+            renderers = new SimpleHtmlReportRenderer()
             configurations = ['runtime']
             excludeGroups = [project.group]
             excludes = []
             importers = []
             filters = []
+        }
+
+        /**
+         * Use #renderers instead
+         */
+        @Deprecated
+        void setRenderer(ReportRenderer renderer) {
+            renderers = renderer
+        }
+
+        /**
+         * Use #renderers instead
+         */
+        @Deprecated
+        ReportRenderer getRenderer() {
+            if (renderers != null && renderers.size() > 0) {
+                return renderers[0]
+            }
+            return null
         }
 
         boolean isExcluded(ResolvedDependency module) {
@@ -44,7 +63,8 @@ class LicenseReportPlugin implements Plugin<Project> {
         // configuration snapshot for the up-to-date check
         private String getSnapshot() {
             StringBuilder builder = new StringBuilder()
-            builder.append(renderer.class.name)
+
+            renderers.each { builder.append(it.class.name) }
             importers.each { builder.append(it.class.name) }
             filters.each { builder.append(it.class.name) }
             configurations.each { builder.append(it) }

--- a/src/main/groovy/com/github/jk1/license/ReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/ReportTask.groovy
@@ -38,7 +38,9 @@ class ReportTask extends DefaultTask {
             data = it.filter(data)
         }
         LOGGER.info("Building report for project ${getProject().name}")
-        config.renderer.render(data)
+        config.renderers.each {
+            it.render(data)
+        }
         LOGGER.info("Dependency license report for project ${getProject().name} created in ${config.outputDir}")
     }
 }

--- a/src/main/groovy/com/github/jk1/license/render/MultiReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/MultiReportRenderer.groovy
@@ -2,6 +2,10 @@ package com.github.jk1.license.render
 
 import com.github.jk1.license.ProjectData
 
+/**
+ * @deprecated use the {@link com.github.jk1.license.LicenseReportPlugin.LicenseReportExtension#renderers} array instead
+ */
+@Deprecated
 public class MultiReportRenderer implements ReportRenderer {
 
     private ReportRenderer[] renderers = {}

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -41,7 +41,7 @@ class LicenseBundleNormalizerSpec extends Specification {
             licenseReport {
                 outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
                 filters = new LicenseBundleNormalizer("$normalizerFile.absolutePath")
-                renderer = new JsonReportRenderer()
+                renderers = new JsonReportRenderer()
                 configurations = ['forTesting']
             }
         """
@@ -150,7 +150,7 @@ class LicenseBundleNormalizerSpec extends Specification {
             licenseReport {
                 outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
                 filters = new LicenseBundleNormalizer()
-                renderer = new JsonReportRenderer()
+                renderers = new JsonReportRenderer()
                 configurations = ['forTesting']
             }
             dependencies {
@@ -198,7 +198,7 @@ class LicenseBundleNormalizerSpec extends Specification {
             licenseReport {
                 outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
                 filters = [ new LicenseBundleNormalizer() ]
-                renderer = new JsonReportRenderer()
+                renderers = new JsonReportRenderer()
                 configurations = ['forTesting1', 'forTesting2']
             }
 


### PR DESCRIPTION
Instead of using the MultiReportRenderer class, the plugin now supports registering
of several renderers with an array. This is streamlined to all the other fields in
the extension.

So now

```
licenseReport {
    renderers = [new JsonReportRenderer(), new MyRenderer()]
}
```

is supported instead of 


```
licenseReport {
    renderer = new MultiReportRenderer(new JsonReportRenderer(), new MyRenderer())
}
```

For backward compatibility reason, the old syntax works as well, but is marked as deprecated.