### PR TITLE
License file normalisation

### DIFF
--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -70,7 +70,21 @@ class License {
 
 @Canonical
 class LicenseFileData {
+
+    /**
+     * @Deprecated Use #fileDetails instead. This will be removed in the future
+     */
+    @Deprecated
     Collection<String> files = []
+
+    Collection<LicenseFileDetails> fileDetails = []
+}
+
+@Canonical
+class LicenseFileDetails {
+    String file
+    String license
+    String licenseUrl
 }
 
 @Canonical

--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -35,7 +35,7 @@ class LicenseFilesReader {
                 def data = new LicenseFileData()
                 files.forEach {
                     data.files << it
-                    data.fileDetails << new LicenseFileDetails(file: it)
+                    data.fileDetails << createFileDetails(it)
                 }
                 return data
                 break
@@ -83,4 +83,24 @@ class LicenseFilesReader {
         return str.substring(pos + separator.length())
     }
 
+    private LicenseFileDetails createFileDetails(String file) {
+        String moduleLicense = null
+        String moduleLicenseUrl = null
+
+        def text = new File(config.outputDir, file).text
+        if (text.contains('Apache License, Version 2.0')) {
+            moduleLicense = 'Apache License, Version 2.0'
+            moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'
+        }
+        if (text.contains('Apache Software License, Version 1.1')) {
+            moduleLicense = 'Apache Software License, Version 1.1'
+            moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-1.1'
+        }
+        if (text.contains('CDDL')) {
+            moduleLicense = 'COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0'
+            moduleLicenseUrl = 'http://opensource.org/licenses/CDDL-1.0'
+        }
+
+        new LicenseFileDetails(file: file, license: moduleLicense, licenseUrl: moduleLicenseUrl)
+    }
 }

--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -1,6 +1,7 @@
 package com.github.jk1.license.reader
 
 import com.github.jk1.license.LicenseFileData
+import com.github.jk1.license.LicenseFileDetails
 import com.github.jk1.license.LicenseReportPlugin.LicenseReportExtension
 import com.github.jk1.license.ReportTask
 import com.github.jk1.license.util.Files
@@ -29,7 +30,14 @@ class LicenseFilesReader {
             case "zip":
             case "jar":
                 Collection<String> files = readLicenseFiles(artifact, new ZipFile(artifact.file, ZipFile.OPEN_READ))
-                return files.isEmpty() ? null : new LicenseFileData(files)
+                if (files.isEmpty()) return null
+
+                def data = new LicenseFileData()
+                files.forEach {
+                    data.files << it
+                    data.fileDetails << new LicenseFileDetails(file: it)
+                }
+                return data
                 break
             default:
                 return null

--- a/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
@@ -56,11 +56,11 @@ class CsvReportRenderer extends SingleInfoReportRenderer {
         }
 
         data.allDependencies.sort().each {
-            renderDependency(output, config, it)
+            renderDependency(output, it)
         }
     }
 
-    void renderDependency(File output, LicenseReportPlugin.LicenseReportExtension config, ModuleData data) {
+    void renderDependency(File output, ModuleData data) {
         def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(data)
 
         String artifact = "${data.group}:${data.name}:${data.version}"

--- a/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
@@ -61,7 +61,7 @@ class CsvReportRenderer extends SingleInfoReportRenderer {
     }
 
     void renderDependency(File output, LicenseReportPlugin.LicenseReportExtension config, ModuleData data) {
-        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(config, data)
+        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(data)
 
         String artifact = "${data.group}:${data.name}:${data.version}"
         output << "${quote(artifact)}$separator${quote(moduleUrl)}$separator${quote(moduleLicense)}$separator${quote(moduleLicenseUrl)}$separator$nl"

--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -329,9 +329,9 @@ class InventoryHtmlReportRenderer implements ReportRenderer {
             }
         }
 
-        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().files.isEmpty()) {
-            output << section("Embedded license files", data.licenseFiles.first().files.collect {
-                link(it, it)
+        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().fileDetails.isEmpty()) {
+            output << section("Embedded license files", data.licenseFiles.first().fileDetails.collect {
+                link(it.file, it.file)
             }.join(''))
         }
         output << "</div>\n"

--- a/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
@@ -108,7 +108,7 @@ class JsonReportRenderer implements ReportRenderer {
         allDependencies.collect {
             String moduleName = "${it.group}:${it.name}"
             String moduleVersion = it.version
-            def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = singleModuleLicenseInfo(config, it)
+            def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = singleModuleLicenseInfo(it)
             trimAndRemoveNullEntries([moduleName      : moduleName,
                                       moduleUrl       : moduleUrl,
                                       moduleVersion   : moduleVersion,
@@ -121,7 +121,7 @@ class JsonReportRenderer implements ReportRenderer {
         allDependencies.collect {
             String moduleName = "${it.group}:${it.name}"
             String moduleVersion = it.version
-            def info = multiModuleLicenseInfo(config, it)
+            def info = multiModuleLicenseInfo(it)
 
             def jsonLicenseList = info.licenses.collect {
                 [moduleLicense: it.name, moduleLicenseUrl: it.url]

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -46,10 +46,10 @@ class LicenseDataCollector {
         // several licenses are available
         if (info.licenses.isEmpty() || !info.licenses.last().url || alwaysCheckLicenseFiles) {
             data.licenseFiles.each {
-                it.files.each {
+                it.fileDetails.each {
                     String moduleLicense = null
                     String moduleLicenseUrl = null
-                    def text = new File(config.outputDir, it).text
+                    def text = new File(config.outputDir, it.file).text
                     if (text.contains('Apache License, Version 2.0')) {
                         moduleLicense = 'Apache License, Version 2.0'
                         moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -1,13 +1,13 @@
 package com.github.jk1.license.render
 
 import com.github.jk1.license.License
-import com.github.jk1.license.LicenseReportPlugin
+import com.github.jk1.license.LicenseFileDetails
 import com.github.jk1.license.ModuleData
 
 class LicenseDataCollector {
 
-    protected static List<String> singleModuleLicenseInfo(LicenseReportPlugin.LicenseReportExtension config, ModuleData data) {
-        def info = multiModuleLicenseInfo(config, data, false)
+    protected static List<String> singleModuleLicenseInfo(ModuleData data) {
+        def info = multiModuleLicenseInfo(data)
         def moduleUrl = lastOrNull(info.moduleUrls)
         def license = lastOrNull(info.licenses)
         def moduleLicense = license?.name
@@ -16,8 +16,7 @@ class LicenseDataCollector {
         [moduleUrl, moduleLicense, moduleLicenseUrl]
     }
 
-    protected static MultiLicenseInfo multiModuleLicenseInfo(
-        LicenseReportPlugin.LicenseReportExtension config, ModuleData data, boolean alwaysCheckLicenseFiles = true) {
+    protected static MultiLicenseInfo multiModuleLicenseInfo(ModuleData data) {
         MultiLicenseInfo info = new MultiLicenseInfo()
 
         data.manifests.each {
@@ -41,32 +40,9 @@ class LicenseDataCollector {
             }
         }
 
-        // Check just here for backward compatibility reason of "simple" json-renderer.
-        // think about removing this at all and risk that the simple-renderers gets a different result in case
-        // several licenses are available
-        if (info.licenses.isEmpty() || !info.licenses.last().url || alwaysCheckLicenseFiles) {
-            data.licenseFiles.each {
-                it.fileDetails.each {
-                    String moduleLicense = null
-                    String moduleLicenseUrl = null
-                    def text = new File(config.outputDir, it.file).text
-                    if (text.contains('Apache License, Version 2.0')) {
-                        moduleLicense = 'Apache License, Version 2.0'
-                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'
-                    }
-                    if (text.contains('Apache Software License, Version 1.1')) {
-                        moduleLicense = 'Apache Software License, Version 1.1'
-                        moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-1.1'
-                    }
-                    if (text.contains('CDDL')) {
-                        moduleLicense = 'COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0'
-                        moduleLicenseUrl = 'http://opensource.org/licenses/CDDL-1.0'
-                    }
-
-                    if (moduleLicense || moduleLicenseUrl) {
-                        info.licenses << new License(name: moduleLicense, url: moduleLicenseUrl)
-                    }
-                }
+        data.licenseFiles*.fileDetails.flatten().each { LicenseFileDetails details ->
+            if (details.license || details.licenseUrl) {
+                info.licenses << new License(name: details.license, url: details.licenseUrl)
             }
         }
         info

--- a/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
@@ -104,9 +104,9 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
                 }
             }
         }
-        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().files.isEmpty()) {
+        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().fileDetails.isEmpty()) {
             output << '<p><strong>Embedded license files:</strong> '
-            output << data.licenseFiles.first().files.collect({ "<a href=\"$it\">$it</a> " }).join('')
+            output << data.licenseFiles.first().fileDetails.collect({ "<a href=\"$it.file\">$it.file</a> " }).join('')
             output << '</p>'
         }
     }

--- a/src/main/groovy/com/github/jk1/license/render/SingleInfoReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SingleInfoReportRenderer.groovy
@@ -14,6 +14,6 @@ abstract class SingleInfoReportRenderer implements ReportRenderer {
      */
     @Deprecated
     protected List<String> moduleLicenseInfo(LicenseReportExtension config, ModuleData data) {
-        return LicenseDataCollector.singleModuleLicenseInfo(config, data)
+        return LicenseDataCollector.singleModuleLicenseInfo(data)
     }
 }

--- a/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
@@ -98,10 +98,10 @@ This report was generated at ${new Date()}.
                 }
             }
         }
-        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().files.isEmpty()) {
+        if (!data.licenseFiles.isEmpty() && !data.licenseFiles.first().fileDetails.isEmpty()) {
             output << 'Embedded license: '
             output << "\n\n"
-            output << data.licenseFiles.first().files.collect({ "                    ****************************************                    \n\n" + new File("$config.outputDir/$it").text + "\n"}).join('')
+            output << data.licenseFiles.first().fileDetails.collect({ "                    ****************************************                    \n\n" + new File("$config.outputDir/$it.file").text + "\n"}).join('')
         }
         output << "--------------------------------------------------------------------------------\n\n"
     }

--- a/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
@@ -72,7 +72,7 @@ class XmlReportRenderer extends SingleInfoReportRenderer {
     private void printDependency(ModuleData data) {
         def moduleName = "${data.group}:${data.name}"
         def moduleVersion = data.version
-        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(config, data)
+        def (String moduleUrl, String moduleLicense, String moduleLicenseUrl) = LicenseDataCollector.singleModuleLicenseInfo(data)
 
         output << "<tr>\n"
         if (moduleUrl) {

--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -20,6 +20,9 @@
     { "bundleName" : "apache2", "licenseNamePattern" : "ASL 2.0" },
     { "bundleName" : "apache2", "licenseUrlPattern" : ".*www.apache.org/licenses/LICENSE-2.0.*" },
     { "bundleName" : "lgpl2.1", "licenseUrlPattern" : ".*www.gnu.org/licenses/old-licenses/lgpl-2.1.html" },
-    { "bundleName" : "mit", "licenseUrlPattern" : ".*www.opensource.org/licenses/mit-license.php" }
+    { "bundleName" : "mit",     "licenseUrlPattern" : ".*www.opensource.org/licenses/mit-license.php" },
+    { "bundleName" : "apache2", "licenseFileContentPattern" : ".*Apache License, Version 2.0.*" },
+    { "bundleName" : "apache1", "licenseFileContentPattern" : ".*Apache Software License, Version 1.1.*" },
+    { "bundleName" : "cddl1",   "licenseFileContentPattern" : ".*CDDL.*" }
   ]
 }

--- a/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
@@ -1,0 +1,55 @@
+package com.github.jk1.license
+
+import com.github.jk1.license.reader.RawProjectDataJsonRenderer
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+abstract class AbstractGradleRunnerFunctionalSpec extends Specification {
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+    File outputDir
+    File rawJsonFile
+
+    List<File> pluginClasspath
+    JsonSlurper jsonSlurper = new JsonSlurper()
+
+    def setup() {
+        testProjectDir.create()
+        outputDir = new File(testProjectDir.root, "/build/licenses")
+        rawJsonFile = new File(outputDir, RawProjectDataJsonRenderer.RAW_PROJECT_JSON_NAME)
+
+        pluginClasspath = buildPluginClasspathWithTestClasspath()
+
+
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    protected def runGradleBuild() {
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('generateLicenseReport', '--stacktrace')
+            .withPluginClasspath(pluginClasspath)
+            .forwardOutput()
+            .build()
+    }
+
+    static String prettyPrintJson(Object obj) {
+        new JsonBuilder(obj).toPrettyString()
+    }
+
+    static List<File> buildPluginClasspathWithTestClasspath() {
+        // add also the test-classes to the classpath to access some helper-renderers
+        def classpath = PluginUnderTestMetadataReading.readImplementationClasspath()
+        return classpath + classpath.collect {
+            // there is surely a better way to add the test-classpath. Help appreciated.
+            new File(it.parentFile, "test")
+        }
+    }
+
+}

--- a/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
@@ -1,6 +1,6 @@
 package com.github.jk1.license
 
-import com.github.jk1.license.reader.RawProjectDataJsonRenderer
+import com.github.jk1.license.render.RawProjectDataJsonRenderer
 import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import org.gradle.testkit.runner.GradleRunner

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -32,7 +32,6 @@ class ProjectBuilder extends BuilderSupport {
 
     @Override
     protected Object createNode(Object name, Map map) {
-        println("Create node $name - $map -- $current")
         switch(name) {
             case "license": return addLicense(null, map)
             case "importedModule": return addImportedModule(map)
@@ -43,7 +42,6 @@ class ProjectBuilder extends BuilderSupport {
 
     @Override
     protected Object createNode(Object name, Map map, Object id) {
-        println("Create node $name - $id - $map -- $current")
         switch(name) {
             case "license": return addLicense(id, map)
             default: throw new IllegalArgumentException("Invalid keyword $name")

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -212,10 +212,16 @@ class ProjectBuilder extends BuilderSupport {
     }
 
     static String json(ProjectData data) {
-        def project = data.project
-        data.project = null
-        def str = new JsonBuilder(data).toPrettyString()
-        data.project = project
-        str
+        def configurationsString = new JsonBuilder(data.configurations).toPrettyString()
+        def importedModulesString = new JsonBuilder(data.importedModules).toPrettyString()
+
+        """{
+"configurations": [
+$configurationsString
+],
+"importedModules": [
+        $importedModulesString
+    ]
+}"""
     }
 }

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -25,7 +25,6 @@ class ProjectBuilder extends BuilderSupport {
             case "pom": return addPom(id)
             case "manifest": return addManifest(id)
             case "license": return addLicense(id, null)
-            case "licenseFile": return addLicenseFiles(id)
             case "importedModulesBundle": return addImportedModulesBundle(id)
             default: throw new IllegalArgumentException("Invalid keyword $name")
         }
@@ -37,6 +36,7 @@ class ProjectBuilder extends BuilderSupport {
         switch(name) {
             case "license": return addLicense(null, map)
             case "importedModule": return addImportedModule(map)
+            case "licenseFile": return addLicenseFiles(map)
             default: throw new IllegalArgumentException("Invalid keyword $name")
         }
     }
@@ -139,11 +139,12 @@ class ProjectBuilder extends BuilderSupport {
         manifest
     }
 
-    private LicenseFileData addLicenseFiles(String id) {
+    private LicenseFileData addLicenseFiles(Map map) {
         ModuleData module = (ModuleData)current
 
         def licenseFiles = new LicenseFileData(
-            files: [id]
+            files: [map.file],
+            fileDetails: [new LicenseFileDetails(map)]
         )
 
         module.licenseFiles << licenseFiles

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
@@ -165,14 +165,17 @@ class ProjectBuilderSpec extends Specification {
         ProjectData data = builder.project {
             configuration("runtime") {
                 module("mod1") {
-                    licenseFile("file1")
-                    licenseFile("file2")
+                    licenseFile(file: "file1", license: "lic1", licenseUrl: "licUrl1")
+                    licenseFile(file: "file2", license: "lic2", licenseUrl: "licUrl2")
                 }
             }
         }
 
         then:
         data.configurations*.dependencies.flatten().licenseFiles.flatten().files.flatten() == ["file1", "file2"]
+        data.configurations*.dependencies.flatten().licenseFiles.flatten().fileDetails.flatten()*.file == ["file1", "file2"]
+        data.configurations*.dependencies.flatten().licenseFiles.flatten().fileDetails.flatten()*.license == ["lic1", "lic2"]
+        data.configurations*.dependencies.flatten().licenseFiles.flatten().fileDetails.flatten()*.licenseUrl == ["licUrl1", "licUrl2"]
         data.importedModules.isEmpty()
     }
 

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -94,9 +94,9 @@ class ProjectReaderFuncSpec extends Specification {
                 "license": null
             },
             {
-                "licenseUrl": null,
+                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
-                "license": null
+                "license": "Apache License, Version 2.0"
             }
         ],
         "files": [

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -1,0 +1,122 @@
+package com.github.jk1.license.reader
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ProjectReaderFuncSpec extends Specification {
+
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+    File outputDir
+    File rawJsonFile
+    List<File> pluginClasspath
+    JsonSlurper jsonSlurper = new JsonSlurper()
+
+    def setup() {
+        testProjectDir.create()
+        outputDir = new File(testProjectDir.root, "/build/licenses")
+        rawJsonFile = new File(outputDir, RawProjectDataJsonRenderer.RAW_PROJECT_JSON_NAME)
+
+        buildFile = testProjectDir.newFile('build.gradle')
+        buildFile << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+            }
+            configurations {
+                forTesting
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                outputDir = "$outputDir.absolutePath"
+                renderer = new com.github.jk1.license.reader.RawProjectDataJsonRenderer()
+                configurations = ['forTesting']
+            }
+        """
+
+        // add also the test-classes to the classpath to access some helper-renderers
+        def classpath = PluginUnderTestMetadataReading.readImplementationClasspath()
+        pluginClasspath = classpath + classpath.collect {
+            // there is surely a better way to add the test-classpath. Help appreciated.
+            new File(it.parentFile, "test")
+        }
+    }
+
+    def "it stores the licenses of a jar-file into the output-dir"() {
+        buildFile << """
+            dependencies {
+                forTesting "org.apache.commons:commons-lang3:3.7" // has NOTICE.txt and LICENSE.txt
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        new File(outputDir, "commons-lang3-3.7.jar/META-INF/NOTICE.txt").exists()
+        new File(outputDir, "commons-lang3-3.7.jar/META-INF/LICENSE.txt").exists()
+    }
+
+    def "the project-data contains the license-file information"() {
+        buildFile << """
+            dependencies {
+                forTesting "org.apache.commons:commons-lang3:3.7" // has NOTICE.txt and LICENSE.txt
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+        def resultFileGPath = jsonSlurper.parse(rawJsonFile)
+        def licenseFilesGPath = resultFileGPath.configurations*.dependencies.flatten().licenseFiles.flatten()
+        def licenseFileString = prettyPrintJson(licenseFilesGPath)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        licenseFileString == """[
+    {
+        "fileDetails": [
+            {
+                "licenseUrl": null,
+                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                "license": null
+            },
+            {
+                "licenseUrl": null,
+                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                "license": null
+            }
+        ],
+        "files": [
+            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+        ]
+    }
+]"""
+    }
+
+
+    private def runGradleBuild() {
+        GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('generateLicenseReport', '--stacktrace')
+            .withPluginClasspath(pluginClasspath)
+            .build()
+    }
+
+    private static String prettyPrintJson(Object obj) {
+        new JsonBuilder(obj).toPrettyString()
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -20,7 +20,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
             import com.github.jk1.license.render.*
             licenseReport {
                 outputDir = "$outputDir.absolutePath"
-                renderer = new com.github.jk1.license.reader.RawProjectDataJsonRenderer()
+                renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = ['forTesting']
             }
         """

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -1,30 +1,11 @@
 package com.github.jk1.license.reader
 
-import groovy.json.JsonBuilder
-import groovy.json.JsonSlurper
-import org.gradle.testkit.runner.GradleRunner
+import com.github.jk1.license.AbstractGradleRunnerFunctionalSpec
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
-class ProjectReaderFuncSpec extends Specification {
-
-    @Rule
-    TemporaryFolder testProjectDir = new TemporaryFolder()
-    File buildFile
-    File outputDir
-    File rawJsonFile
-    List<File> pluginClasspath
-    JsonSlurper jsonSlurper = new JsonSlurper()
+class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
 
     def setup() {
-        testProjectDir.create()
-        outputDir = new File(testProjectDir.root, "/build/licenses")
-        rawJsonFile = new File(outputDir, RawProjectDataJsonRenderer.RAW_PROJECT_JSON_NAME)
-
-        buildFile = testProjectDir.newFile('build.gradle')
         buildFile << """
             plugins {
                 id 'com.github.jk1.dependency-license-report'
@@ -43,13 +24,6 @@ class ProjectReaderFuncSpec extends Specification {
                 configurations = ['forTesting']
             }
         """
-
-        // add also the test-classes to the classpath to access some helper-renderers
-        def classpath = PluginUnderTestMetadataReading.readImplementationClasspath()
-        pluginClasspath = classpath + classpath.collect {
-            // there is surely a better way to add the test-classpath. Help appreciated.
-            new File(it.parentFile, "test")
-        }
     }
 
     def "it stores the licenses of a jar-file into the output-dir"() {
@@ -105,18 +79,5 @@ class ProjectReaderFuncSpec extends Specification {
         ]
     }
 ]"""
-    }
-
-
-    private def runGradleBuild() {
-        GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments('generateLicenseReport', '--stacktrace')
-            .withPluginClasspath(pluginClasspath)
-            .build()
-    }
-
-    private static String prettyPrintJson(Object obj) {
-        new JsonBuilder(obj).toPrettyString()
     }
 }

--- a/src/test/groovy/com/github/jk1/license/reader/RawProjectDataJsonRenderer.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/RawProjectDataJsonRenderer.groovy
@@ -6,7 +6,7 @@ import com.github.jk1.license.render.ReportRenderer
 import groovy.json.JsonBuilder
 
 class RawProjectDataJsonRenderer implements ReportRenderer {
-    static String RAW_PROJECT_JSON_NAME = "raw-project-data.json"
+    static final String RAW_PROJECT_JSON_NAME = "raw-project-data.json"
 
     @Override
     void render(ProjectData data) {

--- a/src/test/groovy/com/github/jk1/license/reader/RawProjectDataJsonRenderer.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/RawProjectDataJsonRenderer.groovy
@@ -1,0 +1,25 @@
+package com.github.jk1.license.reader
+
+import com.github.jk1.license.LicenseReportPlugin
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.render.ReportRenderer
+import groovy.json.JsonBuilder
+
+class RawProjectDataJsonRenderer implements ReportRenderer {
+    static String RAW_PROJECT_JSON_NAME = "raw-project-data.json"
+
+    @Override
+    void render(ProjectData data) {
+        LicenseReportPlugin.LicenseReportExtension config = data.project?.licenseReport
+        File outputFile = new File(config.outputDir, RAW_PROJECT_JSON_NAME)
+        outputFile.createNewFile()
+
+        def project = data.project
+        data.project = null
+
+        def json = new JsonBuilder(data).toPrettyString()
+        outputFile << json
+
+        data.project = project
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
@@ -36,7 +36,7 @@ class JsonReportRendererSpec extends Specification {
                     pom("pom1") {
                         license(APACHE2_LICENSE(), url: "https://www.apache.org/licenses/LICENSE-2.0")
                     }
-                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0")
+                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }
@@ -49,7 +49,7 @@ class JsonReportRendererSpec extends Specification {
                         license(APACHE2_LICENSE())
                         license(MIT_LICENSE())
                     }
-                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0")
+                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }
@@ -76,14 +76,14 @@ class JsonReportRendererSpec extends Specification {
             "moduleUrl": "http://dummy-pom-project-url",
             "moduleVersion": "0.0.1",
             "moduleLicense": "Apache License, Version 2.0",
-            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+            "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
         },
         {
             "moduleName": "dummy-group:mod2",
             "moduleUrl": "http://dummy-pom-project-url",
             "moduleVersion": "0.0.1",
             "moduleLicense": "Apache License, Version 2.0",
-            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+            "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
         }
     ],
     "importedModules": [
@@ -131,7 +131,7 @@ class JsonReportRendererSpec extends Specification {
                 },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         },
@@ -162,7 +162,7 @@ class JsonReportRendererSpec extends Specification {
                 },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         }

--- a/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
@@ -36,7 +36,7 @@ class JsonReportRendererSpec extends Specification {
                     pom("pom1") {
                         license(APACHE2_LICENSE())
                     }
-                    licenseFile("apache2-license.txt")
+                    licenseFile(file: "apache2-license.txt")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }
@@ -49,7 +49,7 @@ class JsonReportRendererSpec extends Specification {
                         license(APACHE2_LICENSE())
                         license(MIT_LICENSE())
                     }
-                    licenseFile("apache2-license.txt")
+                    licenseFile(file: "apache2-license.txt")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }

--- a/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
@@ -34,9 +34,9 @@ class JsonReportRendererSpec extends Specification {
             configuration("runtime") {
                 module("mod1") {
                     pom("pom1") {
-                        license(APACHE2_LICENSE())
+                        license(APACHE2_LICENSE(), url: "https://www.apache.org/licenses/LICENSE-2.0")
                     }
-                    licenseFile(file: "apache2-license.txt")
+                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }
@@ -49,7 +49,7 @@ class JsonReportRendererSpec extends Specification {
                         license(APACHE2_LICENSE())
                         license(MIT_LICENSE())
                     }
-                    licenseFile(file: "apache2-license.txt")
+                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0")
                     manifest("mani1") {
                         license("Apache 2.0")
                     }
@@ -76,14 +76,14 @@ class JsonReportRendererSpec extends Specification {
             "moduleUrl": "http://dummy-pom-project-url",
             "moduleVersion": "0.0.1",
             "moduleLicense": "Apache License, Version 2.0",
-            "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
         },
         {
             "moduleName": "dummy-group:mod2",
             "moduleUrl": "http://dummy-pom-project-url",
             "moduleVersion": "0.0.1",
-            "moduleLicense": "MIT License",
-            "moduleLicenseUrl": "https://opensource.org/licenses/MIT"
+            "moduleLicense": "Apache License, Version 2.0",
+            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
         }
     ],
     "importedModules": [

--- a/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
@@ -25,4 +25,21 @@ class LicenseDataCollectorSpec extends Specification {
         result.licenses.isEmpty()
     }
 
+    def "after normalisation, all license files of all configurations are normalized"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    licenseFile(file: "apache2-license.txt", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                }
+            }
+        }
+
+        when:
+        ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
+        def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
+
+        then:
+        result.licenses*.name == ["Apache License, Version 2.0"]
+        result.licenses*.url == ["https://www.apache.org/licenses/LICENSE-2.0"]
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
@@ -19,7 +19,7 @@ class LicenseDataCollectorSpec extends Specification {
 
         when:
         ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
-        def result = LicenseDataCollector.singleModuleLicenseInfo(null, moduleData)
+        def result = LicenseDataCollector.singleModuleLicenseInfo(moduleData)
 
         then:
         result.licenses.isEmpty()

--- a/src/test/groovy/com/github/jk1/license/render/RawProjectDataJsonRenderer.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/RawProjectDataJsonRenderer.groovy
@@ -1,4 +1,4 @@
-package com.github.jk1.license.reader
+package com.github.jk1.license.render
 
 import com.github.jk1.license.LicenseReportPlugin
 import com.github.jk1.license.ProjectData


### PR DESCRIPTION
Move license-file-content check from renderer to reader and save license-information (if check succeeds) to the model.
Allow to define normalization rules for the license-file-content