### PR TITLE
Add transformation rules by default for the available license bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The normalizer can be enabled via a filter.
 import com.github.jk1.license.filter.*
 ...
 licenseReport {
-    filters = new LicenseBundleNormalizer("$projectDir/config/license-normalizer-bundle.json")
+    filters = new LicenseBundleNormalizer(bundlePath: "$projectDir/config/license-normalizer-bundle.json")
 }
 ```
 

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -32,7 +32,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             import com.github.jk1.license.reader.*
             licenseReport {
                 outputDir = "$outputDir.absolutePath"
-                filters = new LicenseBundleNormalizer("$normalizerFile.absolutePath")
+                filters = new LicenseBundleNormalizer(bundlePath: "$normalizerFile.absolutePath", createDefaultTransformationRules: false)
                 renderer = new MultiReportRenderer(new JsonReportRenderer(onlyOneLicensePerModule: false), new RawProjectDataJsonRenderer())
                 configurations = ['forTesting']
             }

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -34,6 +34,17 @@ class LicenseBundleNormalizerSpec extends Specification {
         new File(pluginOutputDir, "apache2-license.txt") << apache2LicenseFile.text
     }
 
+    def "normalizer constructor can be called with named parameters"() {
+        when:
+        new LicenseBundleNormalizer()
+        new LicenseBundleNormalizer(bundlePath: null)
+        new LicenseBundleNormalizer(createDefaultTransformationRules: false)
+        new LicenseBundleNormalizer(bundlePath: null, createDefaultTransformationRules: false)
+
+        then:
+        noExceptionThrown()
+    }
+
     def "normalize license of manifest (when stored as name)"() {
         normalizerFile << """,
             "transformationRules" : [
@@ -291,7 +302,102 @@ class LicenseBundleNormalizerSpec extends Specification {
         json(result) == json(expected)
     }
 
-    private LicenseBundleNormalizer newNormalizer() {
-        new LicenseBundleNormalizer(normalizerFile.absolutePath)
+    def "a transformation rule is created for each licence-bundle-name as exact match"() {
+        normalizerFile << """}"""
+
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE(), url: "different url") // should be normalized because name matches the bundle-name
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")   // should stay, because name is different
+                    }
+                }
+            }
+        }
+        ProjectData expected = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                    }
+                }
+            }
+        }
+
+        when:
+        def result = newNormalizer(true).filter(projectData)
+
+        then:
+        json(result) == json(expected)
+    }
+
+    def "a transformation rule is created for each licence-bundle-url as exact match"() {
+        normalizerFile << """}"""
+
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE(), name: "different name") // should be normalized because url matches the bundle-url
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")   // should stay, because url is different
+                    }
+                }
+            }
+        }
+        ProjectData expected = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                    }
+                }
+            }
+        }
+
+        when:
+        def result = newNormalizer(true).filter(projectData)
+
+        then:
+        json(result) == json(expected)
+    }
+
+    def "not creating default transformation rules when turned off"() {
+        normalizerFile << """}"""
+
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE(), url: "different url")
+                        license(APACHE2_LICENSE(), name: "different name")
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                    }
+                }
+            }
+        }
+        ProjectData expected = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE(), url: "different url")
+                        license(APACHE2_LICENSE(), name: "different name")
+                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                    }
+                }
+            }
+        }
+
+        when:
+        def result = newNormalizer(false).filter(projectData)
+
+        then:
+        json(result) == json(expected)
+    }
+
+    private LicenseBundleNormalizer newNormalizer(boolean createDefaultTransformationRules = false) {
+        new LicenseBundleNormalizer(bundlePath: normalizerFile.absolutePath, createDefaultTransformationRules: createDefaultTransformationRules)
     }
 }


### PR DESCRIPTION
Often a license name is defined properly, but the url is slightly different (e.g. http instead of https),
but defining a rule is then quite annoying. Therefor, the the normalizer defined its own rules by just
using all the license-bundles and create a name-rule for every bundle where the name-pattern is set to the
license-name of the licence-bundle. This will then normalize all licenses with a valid name, but a
different url. The same is done for the url. So all licenses with the same url, but a differnet name
are also normalized.