### PR TITLE
Ideomatic task and extension registration

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
@@ -17,7 +17,7 @@ class LicenseReportPlugin implements Plugin<Project> {
     void apply(Project project) {
         assertCompatibleGradleVersion()
 
-        project.extensions.add('licenseReport', new LicenseReportExtension(project))
+        project.extensions.create('licenseReport', LicenseReportExtension, project)
         project.task(['type': ReportTask.class], 'generateLicenseReport')
     }
 
@@ -74,7 +74,7 @@ class LicenseReportPlugin implements Plugin<Project> {
         }
 
         // configuration snapshot for the up-to-date check
-        private String getSnapshot() {
+        String getSnapshot() {
             StringBuilder builder = new StringBuilder()
 
             renderers.each { builder.append(it.class.name) }

--- a/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
@@ -18,7 +18,7 @@ class LicenseReportPlugin implements Plugin<Project> {
         assertCompatibleGradleVersion()
 
         project.extensions.create('licenseReport', LicenseReportExtension, project)
-        project.task(['type': ReportTask.class], 'generateLicenseReport')
+        project.tasks.create('generateLicenseReport', ReportTask)
     }
 
     private void assertCompatibleGradleVersion() {


### PR DESCRIPTION
This actually came up because when using the plugin with the Gradle-Kotlin-DSL, the type of the extension can't be inferred. With other plugins this work. The reason seems to be in the way, the extension is registered.

Also this affects the private fields/methods of the extension, because the extension is wrapped in a Proxy, and the proxy doesn't seem to call private ones.