### PR TITLE
Fix wrong pom url

### DIFF
--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -58,8 +58,8 @@ class ConfigurationReader {
     private static class ResolvedDependencyComparator implements Comparator<ResolvedDependency>{
         @Override
         int compare(ResolvedDependency first, ResolvedDependency second) {
-            int result = first.moduleGroup.compareTo(second.moduleGroup)
-            result == 0 ? first.moduleName.compareTo(second.moduleName) : result
+            first.moduleGroup <=> second.moduleGroup ?:
+                first.moduleName <=> second.moduleName
         }
     }
 }

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -24,7 +24,7 @@ class PomReader {
 
     PomData readPomData(Project project, ResolvedArtifact artifact) {
         resolver = new CachingArtifactResolver(project)
-        GPathResult pomContent = slurpPom(artifact.file)
+        GPathResult pomContent = findAndSlurpPom(artifact.file)
 
         if (!pomContent) {
             pomContent = fetchRemoteArtifactPom(artifact)
@@ -38,13 +38,52 @@ class PomReader {
         }
     }
 
+    private GPathResult findAndSlurpPom(File toSlurp) {
+        if (toSlurp.name == "pom.xml") {
+            LOGGER.debug("Slurping pom from pom.xml file: $toSlurp")
+            return slurpPomItself(toSlurp)
+        }
+
+        String fileSuffix = Files.getExtension(toSlurp.name)?.toLowerCase()
+        if (!fileSuffix) {
+            LOGGER.debug("No file suffix on potential pom-containing file: $toSlurp")
+            return null
+        }
+        switch (fileSuffix) {
+            case "pom":
+                LOGGER.debug("Slurping pom from *.pom file: $toSlurp")
+                return slurpPomItself(toSlurp)
+            case "zip":
+            case "jar":
+                LOGGER.debug("Processing pom from archive: $toSlurp")
+                return slurpFirstPomFromZip(toSlurp)
+        }
+
+        LOGGER.debug("No idea how to process a pom from: $toSlurp")
+        return null
+    }
+
+    private GPathResult slurpPomItself(File toSlurp) {
+        return createParser().parse(toSlurp)
+    }
+
+    private GPathResult slurpFirstPomFromZip(File archiveToSearch) {
+        ZipFile archive = new ZipFile(archiveToSearch, ZipFile.OPEN_READ)
+        ZipEntry pomEntry = archive.entries().toList().find { ZipEntry entry ->
+            entry.name.endsWith("pom.xml") || entry.name.endsWith(".pom")
+        }
+        LOGGER.debug("Searching for POM file in $archiveToSearch -- found ${pomEntry?.name}")
+        if (!pomEntry) return null
+        return createParser().parse(archive.getInputStream(pomEntry))
+    }
+
     private GPathResult fetchRemoteArtifactPom(ResolvedArtifact artifact) {
         Collection<ResolvedArtifact> artifacts = fetchRemoteArtifactPoms(artifact.moduleVersion.id.group,
             artifact.moduleVersion.id.name, artifact.moduleVersion.id.version)
 
         return artifacts.collect {
             try {
-                slurpPom(it.file)
+                findAndSlurpPom(it.file)
             } catch (Exception e) {
                 LOGGER.warn("Error slurping pom from $it.file", e)
                 null
@@ -71,103 +110,78 @@ class PomReader {
         }
     }
 
-    private GPathResult slurpPom(File toSlurp) {
-        if (toSlurp.name == "pom.xml") {
-            LOGGER.debug("Slurping pom from pom.xml file: $toSlurp")
-            return slurpPomItself(toSlurp)
-        }
-
-        String fileSuffix = Files.getExtension(toSlurp.name)?.toLowerCase()
-        if (!fileSuffix) {
-            LOGGER.debug("No file suffix on potential pom-containing file: $toSlurp")
-            return null
-        }
-        switch (fileSuffix) {
-            case "pom":
-                LOGGER.debug("Slurping pom from *.pom file: $toSlurp")
-                return slurpPomItself(toSlurp)
-            case "zip":
-            case "jar":
-                LOGGER.debug("Processing pom from archive: $toSlurp")
-                return slurpPomFromZip(toSlurp)
-        }
-
-        LOGGER.debug("No idea how to process a pom from: $toSlurp")
-        return null
-    }
-
-    private GPathResult slurpPomFromZip(File archiveToSearch) {
-        ZipFile archive = new ZipFile(archiveToSearch, ZipFile.OPEN_READ)
-        ZipEntry pomEntry = archive.entries().toList().find { ZipEntry entry ->
-            entry.name.endsWith("pom.xml") || entry.name.endsWith(".pom")
-        }
-        LOGGER.debug("Searching for POM file in $archiveToSearch -- found ${pomEntry?.name}")
-        if (!pomEntry) return null
-        return createParser().parse(archive.getInputStream(pomEntry))
-    }
-
-    private GPathResult slurpPomItself(File toSlurp) {
-        return createParser().parse(toSlurp)
-    }
-
     private PomData readPomFile(GPathResult pomContent) {
-        return readPomFile(pomContent, new PomData())
+        List<GPathResult> children = collectChildGPaths(pomContent)
+        return createPomData(pomContent, children)
     }
 
-    private PomData readPomFile(GPathResult pomContent, PomData pomData) {
-        if (!pomContent) {
-            LOGGER.info("No content found in pom")
-            return null
-        }
+    private List<GPathResult> collectChildGPaths(GPathResult rootPomGPath) {
+        List<GPathResult> results = []
 
-        LOGGER.debug("POM content children: ${pomContent.children()*.name() as Set}")
-        if (!pomContent.parent.children().isEmpty()) {
-            LOGGER.debug("Processing parent POM: ${pomContent.parent.children()*.name()}")
-            GPathResult parentContent = pomContent.parent
+        LOGGER.debug("POM content children: ${rootPomGPath.children()*.name() as Set}")
+        if (rootPomGPath.parent.children().isEmpty()) return []
 
-            String groupId = parentContent.groupId.text()
-            String artifactId = parentContent.artifactId.text()
-            String version = parentContent.version.text()
+        LOGGER.debug("Processing parent POM: ${rootPomGPath.parent.children()*.name()}")
+        GPathResult parentContent = rootPomGPath.parent
 
-            Collection<ResolvedArtifact> parentArtifacts = fetchRemoteArtifactPoms(groupId, artifactId, version)
+        String groupId = parentContent.groupId.text()
+        String artifactId = parentContent.artifactId.text()
+        String version = parentContent.version.text()
 
-            if (parentArtifacts) {
-                (parentArtifacts*.file as Set).each { File file ->
-                    LOGGER.debug("Processing parent POM file: $file")
-                    pomData = readPomFile(createParser().parse(file), pomData)
+        Collection<ResolvedArtifact> parentArtifacts = fetchRemoteArtifactPoms(groupId, artifactId, version)
+
+        if (parentArtifacts) {
+            (parentArtifacts*.file as Set).each { File file ->
+                LOGGER.debug("Processing parent POM file: $file")
+                GPathResult childPomGPath = slurpPomItself(file)
+
+                if (childPomGPath) {
+                    results += childPomGPath
+                    results += collectChildGPaths(childPomGPath)
                 }
             }
         }
+        return results
+    }
 
-        pomData.name = pomContent.name?.text()
-        pomData.description = pomContent.description?.text()
-        pomData.projectUrl = pomContent.url?.text()
-        pomData.inceptionYear = pomContent.inceptionYear?.text()
+    private PomData createPomData(GPathResult rootPom, List<GPathResult> childPoms) {
+        List<GPathResult> allPoms = [rootPom] + childPoms
 
-        def organizationName = pomContent.organization?.name?.text()
-        def organizationUrl = pomContent.organization?.url?.text()
-        if (organizationName || organizationUrl) {
-            pomData.organization = new PomOrganization(name: organizationName, url: organizationUrl)
-        }
+        PomData pomData = new PomData()
 
-        pomData.developers = pomContent.developers?.developer?.collect { GPathResult developer ->
+        pomData.name = rootPom.name?.text()
+        pomData.description = rootPom.description?.text()
+        pomData.projectUrl = rootPom.url?.text()
+        pomData.inceptionYear = rootPom.inceptionYear?.text()
+
+        pomData.developers = rootPom.developers?.developer?.collect { GPathResult developer ->
             new PomDeveloper(
-                    name: developer.name?.text(),
-                    email: developer.email?.text(),
-                    url: developer.url?.text()
+                name: developer.name?.text(),
+                email: developer.email?.text(),
+                url: developer.url?.text()
             )
         }
 
-        LOGGER.debug("POM license : ${pomContent.licenses.children()*.name() as Set}")
+        allPoms.reverse().each { pom ->
+            def organizationName = pom.organization?.name?.text()
+            def organizationUrl = pom.organization?.url?.text()
+            if (organizationName || organizationUrl) {
+                pomData.organization = new PomOrganization(name: organizationName, url: organizationUrl)
+            }
+        }
 
-        pomContent.licenses?.license?.each { GPathResult license ->
-            LOGGER.debug("Processing license: ${license.name.text()}")
-            pomData.licenses << new License(
+        LOGGER.debug("POM license : ${rootPom.licenses.children()*.name() as Set}")
+
+        allPoms.each { pom ->
+            pom.licenses?.license?.each { GPathResult license ->
+                LOGGER.debug("Processing license: ${license.name.text()}")
+                pomData.licenses << new License(
                     name: license.name?.text(),
                     url: license.url?.text(),
                     distribution: license.distribution?.text(),
                     comments: license.comments?.text()
-            )
+                )
+            }
         }
 
         LOGGER.info("Returning pom data: ${pomData.dump()}")

--- a/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
@@ -26,14 +26,15 @@ abstract class AbstractGradleRunnerFunctionalSpec extends Specification {
 
         pluginClasspath = buildPluginClasspathWithTestClasspath()
 
-
         buildFile = testProjectDir.newFile('build.gradle')
     }
 
-    protected def runGradleBuild() {
+    protected def runGradleBuild(List<String> additionalArguments = []) {
+        List<String> args = ['generateLicenseReport', '--stacktrace']
+
         GradleRunner.create()
             .withProjectDir(testProjectDir.root)
-            .withArguments('generateLicenseReport', '--stacktrace')
+            .withArguments(args + additionalArguments)
             .withPluginClasspath(pluginClasspath)
             .forwardOutput()
             .build()

--- a/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
+++ b/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
@@ -64,7 +64,7 @@ class PluginCompatibilityTest extends Specification {
             "moduleVersion": "3.3.1",
             "moduleUrls": [
                 "ehcache-3.3.1.jar/LICENSE.html",
-                "https://github.com/ehcache/sizeof"
+                "http://ehcache.org"
             ],
             "moduleLicenses": [
                 {

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -80,4 +80,629 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
     }
 ]"""
     }
+
+    def "it reads dependencies correctly"() {
+        buildFile << """
+            dependencies {
+                forTesting "org.springframework:spring-tx:3.2.3.RELEASE"
+                forTesting "org.ehcache:ehcache:3.3.1"
+                forTesting "org.apache.commons:commons-lang3:3.7"
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+        def resultFileGPath = jsonSlurper.parse(rawJsonFile)
+        def configurationsGPath = resultFileGPath.configurations
+        def configurationsString = prettyPrintJson(configurationsGPath)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        configurationsString == """[
+    {
+        "dependencies": [
+            {
+                "group": "org.ehcache",
+                "manifests": [
+                    {
+                        "vendor": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
+                        "hasPackagedLicense": true,
+                        "version": "3.3.1",
+                        "license": "LICENSE",
+                        "description": "Ehcache is an open-source caching library, compliant with the JSR-107 standard.",
+                        "url": "ehcache-3.3.1.jar/LICENSE.html",
+                        "name": "ehcache 3"
+                    }
+                ],
+                "version": "3.3.1",
+                "poms": [
+                    {
+                        "developers": [
+                            
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/ehcache/sizeof",
+                        "description": "SizeOf engine, extracted from Ehcache",
+                        "name": "Ehcache SizeOf Engine",
+                        "organization": {
+                            "url": "http://terracotta.org",
+                            "name": "Terracotta"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "ehcache-3.3.1.jar/LICENSE",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "ehcache-3.3.1.jar/NOTICE",
+                                "license": null
+                            }
+                        ],
+                        "files": [
+                            "ehcache-3.3.1.jar/LICENSE",
+                            "ehcache-3.3.1.jar/NOTICE"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "ehcache"
+            },
+            {
+                "group": "aopalliance",
+                "manifests": [
+                    {
+                        "vendor": null,
+                        "hasPackagedLicense": false,
+                        "version": null,
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": null
+                    }
+                ],
+                "version": "1.0",
+                "poms": [
+                    {
+                        "developers": [
+                            
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "http://aopalliance.sourceforge.net",
+                        "description": "AOP Alliance",
+                        "name": "AOP alliance",
+                        "organization": null,
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "",
+                                "url": "",
+                                "name": "Public Domain"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    
+                ],
+                "empty": false,
+                "name": "aopalliance"
+            },
+            {
+                "group": "org.slf4j",
+                "manifests": [
+                    {
+                        "vendor": "SLF4J.ORG",
+                        "hasPackagedLicense": false,
+                        "version": "1.7.7",
+                        "license": null,
+                        "description": "The slf4j API",
+                        "url": null,
+                        "name": "slf4j-api"
+                    }
+                ],
+                "version": "1.7.7",
+                "poms": [
+                    {
+                        "developers": [
+                            
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "http://www.slf4j.org",
+                        "description": "The slf4j API",
+                        "name": "SLF4J API Module",
+                        "organization": {
+                            "url": "http://www.qos.ch",
+                            "name": "QOS.ch"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.opensource.org/licenses/mit-license.php",
+                                "name": "MIT License"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    
+                ],
+                "empty": false,
+                "name": "slf4j-api"
+            },
+            {
+                "group": "org.springframework",
+                "manifests": [
+                    {
+                        "vendor": null,
+                        "hasPackagedLicense": false,
+                        "version": "3.2.3.RELEASE",
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": "spring-core"
+                    }
+                ],
+                "version": "3.2.3.RELEASE",
+                "poms": [
+                    {
+                        "developers": [
+                            {
+                                "url": "",
+                                "email": "jhoeller@vmware.com",
+                                "name": "Juergen Hoeller"
+                            }
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/SpringSource/spring-framework",
+                        "description": "Spring Core",
+                        "name": "Spring Core",
+                        "organization": {
+                            "url": "http://springsource.org/spring-framework",
+                            "name": "SpringSource"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "license": "Apache License, Version 2.0"
+                            }
+                        ],
+                        "files": [
+                            "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                            "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "spring-core"
+            },
+            {
+                "group": "org.apache.commons",
+                "manifests": [
+                    {
+                        "vendor": "The Apache Software Foundation",
+                        "hasPackagedLicense": false,
+                        "version": "3.7.0",
+                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
+                        "url": "http://commons.apache.org/proper/commons-lang/",
+                        "name": "Apache Commons Lang"
+                    }
+                ],
+                "version": "3.7",
+                "poms": [
+                    {
+                        "developers": [
+                            {
+                                "url": "",
+                                "email": "dlr@finemaltcoding.com",
+                                "name": "Daniel Rall"
+                            },
+                            {
+                                "url": "",
+                                "email": "scolebourne@joda.org",
+                                "name": "Stephen Colebourne"
+                            },
+                            {
+                                "url": "",
+                                "email": "bayard@apache.org",
+                                "name": "Henri Yandell"
+                            },
+                            {
+                                "url": "",
+                                "email": "stevencaswell@apache.org",
+                                "name": "Steven Caswell"
+                            },
+                            {
+                                "url": "",
+                                "email": "rdonkin@apache.org",
+                                "name": "Robert Burrell Donkin"
+                            },
+                            {
+                                "url": "",
+                                "email": "ggregory@apache.org",
+                                "name": "Gary D. Gregory"
+                            },
+                            {
+                                "url": "",
+                                "email": "",
+                                "name": "Fredrik Westermarck"
+                            },
+                            {
+                                "url": "",
+                                "email": "jcarman@apache.org",
+                                "name": "James Carman"
+                            },
+                            {
+                                "url": "",
+                                "email": "",
+                                "name": "Niall Pemberton"
+                            },
+                            {
+                                "url": "",
+                                "email": "",
+                                "name": "Matt Benson"
+                            },
+                            {
+                                "url": "",
+                                "email": "joerg.schaible@gmx.de",
+                                "name": "Joerg Schaible"
+                            },
+                            {
+                                "url": "",
+                                "email": "oheger@apache.org",
+                                "name": "Oliver Heger"
+                            },
+                            {
+                                "url": "",
+                                "email": "pbenedict@apache.org",
+                                "name": "Paul Benedict"
+                            },
+                            {
+                                "url": "",
+                                "email": "britter@apache.org",
+                                "name": "Benedikt Ritter"
+                            },
+                            {
+                                "url": "",
+                                "email": "djones@apache.org",
+                                "name": "Duncan Jones"
+                            },
+                            {
+                                "url": "",
+                                "email": "lguibert@apache.org",
+                                "name": "Loic Guibert"
+                            },
+                            {
+                                "url": "",
+                                "email": "chtompki@apache.org",
+                                "name": "Rob Tompkins"
+                            }
+                        ],
+                        "inceptionYear": "2001",
+                        "projectUrl": "http://commons.apache.org/proper/commons-lang/",
+                        "description": "\\n  Apache Commons Lang, a package of Java utility classes for the\\n  classes that are in java.lang's hierarchy, or are considered to be so\\n  standard as to justify existence in java.lang.\\n  ",
+                        "name": "Apache Commons Lang",
+                        "organization": {
+                            "url": "https://www.apache.org/",
+                            "name": "The Apache Software Foundation"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "Apache License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
+                            },
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "license": "Apache License, Version 2.0"
+                            }
+                        ],
+                        "files": [
+                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "commons-lang3"
+            },
+            {
+                "group": "org.springframework",
+                "manifests": [
+                    {
+                        "vendor": null,
+                        "hasPackagedLicense": false,
+                        "version": "3.2.3.RELEASE",
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": "spring-beans"
+                    }
+                ],
+                "version": "3.2.3.RELEASE",
+                "poms": [
+                    {
+                        "developers": [
+                            {
+                                "url": "",
+                                "email": "jhoeller@vmware.com",
+                                "name": "Juergen Hoeller"
+                            }
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/SpringSource/spring-framework",
+                        "description": "Spring Beans",
+                        "name": "Spring Beans",
+                        "organization": {
+                            "url": "http://springsource.org/spring-framework",
+                            "name": "SpringSource"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "license": "Apache License, Version 2.0"
+                            }
+                        ],
+                        "files": [
+                            "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                            "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "spring-beans"
+            },
+            {
+                "group": "commons-logging",
+                "manifests": [
+                    {
+                        "vendor": "Apache Software Foundation",
+                        "hasPackagedLicense": false,
+                        "version": "1.1.1",
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": "Jakarta Commons Logging"
+                    }
+                ],
+                "version": "1.1.1",
+                "poms": [
+                    {
+                        "developers": [
+                            {
+                                "url": "",
+                                "email": "morgand at apache dot org",
+                                "name": "Morgan Delagrange"
+                            },
+                            {
+                                "url": "",
+                                "email": "rwaldhoff at apache org",
+                                "name": "Rodney Waldhoff"
+                            },
+                            {
+                                "url": "",
+                                "email": "craigmcc at apache org",
+                                "name": "Craig McClanahan"
+                            },
+                            {
+                                "url": "",
+                                "email": "sanders at apache dot org",
+                                "name": "Scott Sanders"
+                            },
+                            {
+                                "url": "",
+                                "email": "rdonkin at apache dot org",
+                                "name": "Robert Burrell Donkin"
+                            },
+                            {
+                                "url": "",
+                                "email": "donaldp at apache dot org",
+                                "name": "Peter Donald"
+                            },
+                            {
+                                "url": "",
+                                "email": "costin at apache dot org",
+                                "name": "Costin Manolache"
+                            },
+                            {
+                                "url": "",
+                                "email": "rsitze at apache dot org",
+                                "name": "Richard Sitze"
+                            },
+                            {
+                                "url": "",
+                                "email": "baliuka@apache.org",
+                                "name": "Juozas Baliuka"
+                            },
+                            {
+                                "url": "",
+                                "email": "skitching@apache.org",
+                                "name": "Simon Kitching"
+                            },
+                            {
+                                "url": "",
+                                "email": "dennisl@apache.org",
+                                "name": "Dennis Lundberg"
+                            },
+                            {
+                                "url": "",
+                                "email": "",
+                                "name": "Brian Stansberry"
+                            }
+                        ],
+                        "inceptionYear": "2001",
+                        "projectUrl": "http://commons.apache.org/logging",
+                        "description": "Commons Logging is a thin adapter allowing configurable bridging to other,\\n    well known logging systems.",
+                        "name": "Commons Logging",
+                        "organization": {
+                            "url": "http://www.apache.org/",
+                            "name": "The Apache Software Foundation"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "commons-logging-1.1.1.jar/META-INF/LICENSE",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-logging-1.1.1.jar/META-INF/NOTICE",
+                                "license": null
+                            }
+                        ],
+                        "files": [
+                            "commons-logging-1.1.1.jar/META-INF/LICENSE",
+                            "commons-logging-1.1.1.jar/META-INF/NOTICE"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "commons-logging"
+            },
+            {
+                "group": "org.springframework",
+                "manifests": [
+                    {
+                        "vendor": null,
+                        "hasPackagedLicense": false,
+                        "version": "3.2.3.RELEASE",
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": "spring-tx"
+                    }
+                ],
+                "version": "3.2.3.RELEASE",
+                "poms": [
+                    {
+                        "developers": [
+                            {
+                                "url": "",
+                                "email": "jhoeller@vmware.com",
+                                "name": "Juergen Hoeller"
+                            }
+                        ],
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/SpringSource/spring-framework",
+                        "description": "Spring Transaction",
+                        "name": "Spring Transaction",
+                        "organization": {
+                            "url": "http://springsource.org/spring-framework",
+                            "name": "SpringSource"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "license": "Apache License, Version 2.0"
+                            }
+                        ],
+                        "files": [
+                            "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                            "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "spring-tx"
+            }
+        ],
+        "name": "forTesting"
+    }
+]"""
+    }
 }


### PR DESCRIPTION
Did a few refactorings in the PomReader and then added support to check if pom represents the artifact.
If the pom doesn't represents the artifact (check done by comparing groupId and artifactId)
then the remote pom from the repository is fetched and used.

I tried to make clean commits, so try to review the individual commits, than the actual change (not that much) can be reviewed easier.