### PR TITLE
Further duplication removal

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -17,9 +17,10 @@ class LicenseBundleNormalizer implements DependencyFilter {
     Map<String, NormalizerLicenseBundle> bundleMap
 
     LicenseBundleNormalizer(Map params = ["bundlePath": null, "createDefaultTransformationRules": true]) {
-        String bundlePath = params.bundlePath
-        boolean createDefaultTransformationRules = params.get("createDefaultTransformationRules", true)
+        this(params.bundlePath, params.get("createDefaultTransformationRules", true))
+    }
 
+    LicenseBundleNormalizer(String bundlePath, boolean createDefaultTransformationRules) {
         InputStream inputStream
         if (bundlePath == null) {
             inputStream = getClass().getResourceAsStream("/default-license-normalizer-bundle.json")

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -19,18 +19,6 @@ class LicenseDataCollector {
     protected static MultiLicenseInfo multiModuleLicenseInfo(ModuleData data) {
         MultiLicenseInfo info = new MultiLicenseInfo()
 
-        data.manifests.each {
-            if (it.url) {
-                info.moduleUrls << it.url
-            }
-            if (it.license) {
-                if (isValidUrl(it.license)) {
-                    info.licenses << new License(url: it.license)
-                } else {
-                    info.licenses << new License(name: it.license)
-                }
-            }
-        }
         data.poms.each {
             if (it.projectUrl) {
                 info.moduleUrls << it.projectUrl
@@ -40,9 +28,26 @@ class LicenseDataCollector {
             }
         }
 
+        data.manifests.each { manifest ->
+            if (manifest.url) {
+                info.moduleUrls << manifest.url
+            }
+            if (manifest.license) {
+                if (isValidUrl(manifest.license)) {
+                    if (!info.licenses.find { it.url == manifest.license })
+                        info.licenses << new License(url: manifest.license)
+                } else {
+                    if (!info.licenses.find { it.name == manifest.license })
+                        info.licenses << new License(name: manifest.license)
+                }
+            }
+        }
+
         data.licenseFiles*.fileDetails.flatten().each { LicenseFileDetails details ->
-            if (details.license || details.licenseUrl) {
-                info.licenses << new License(name: details.license, url: details.licenseUrl)
+            if (!info.licenses.find { it.name == details.license }) {
+                if (details.license || details.licenseUrl) {
+                    info.licenses << new License(name: details.license, url: details.licenseUrl)
+                }
             }
         }
         info

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -230,4 +230,8 @@ $configurationsString
     ]
 }"""
     }
+
+    static String json(Object data) {
+        new JsonBuilder(data).toPrettyString()
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -72,7 +72,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
         runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
 
         result.dependencies.size() == 2
-        result.dependencies*.moduleLicenses.flatten()*.moduleLicense.toSet() == ["Apache License, Version 2.0", null].toSet()
+        result.dependencies*.moduleLicenses.flatten()*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
         result.dependencies*.moduleLicenses.flatten()*.moduleLicenseUrl.toSet() == ["https://www.apache.org/licenses/LICENSE-2.0", "http://www.apache.org/licenses/LICENSE-2.0"].toSet()
     }
 
@@ -100,7 +100,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
 
         result.dependencies.size() == 2
         result.dependencies*.moduleLicenses.flatten()*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
-        result.dependencies*.moduleLicenses.flatten()*.moduleLicenseUrl.toSet() == ["https://www.apache.org/licenses/LICENSE-2.0", null].toSet()
+        result.dependencies*.moduleLicenses.flatten()*.moduleLicenseUrl.toSet() == ["https://www.apache.org/licenses/LICENSE-2.0"].toSet()
     }
 
     def "normalizes manifest with pom data"() {
@@ -125,7 +125,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
         runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
 
         result.dependencies*.moduleLicenses.flatten()*.moduleLicense.toSet() == ["Apache License, Version 2.0"].toSet()
-        result.dependencies*.moduleLicenses.flatten()*.moduleLicenseUrl.toSet() == ["http://www.apache.org/licenses/LICENSE-2.0"/*LicenseFile*/, "https://www.apache.org/licenses/LICENSE-2.0"/*Pom*/, null/*Manifest*/].toSet()
+        result.dependencies*.moduleLicenses.flatten()*.moduleLicenseUrl.toSet() == ["https://www.apache.org/licenses/LICENSE-2.0"].toSet()
     }
 
     def "an error is raised when a normalizer file is specified but not available"() {
@@ -183,10 +183,6 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": null
-                },
-                {
-                    "moduleLicense": "Apache License, Version 2.0",
                     "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
@@ -198,10 +194,6 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
                 "http://commons.apache.org/proper/commons-lang/"
             ],
             "moduleLicenses": [
-                {
-                    "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": null
-                },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
                     "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
@@ -338,14 +330,6 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
                 "http://commons.apache.org/proper/commons-lang/"
             ],
             "moduleLicenses": [
-                {
-                    "moduleLicense": null,
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                },
-                {
-                    "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
-                },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
                     "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"

--- a/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
@@ -5,6 +5,9 @@ import com.github.jk1.license.ProjectBuilder
 import com.github.jk1.license.ProjectData
 import spock.lang.Specification
 
+import static com.github.jk1.license.ProjectBuilder.json
+import static com.github.jk1.license.ProjectDataFixture.APACHE2_LICENSE
+
 class LicenseDataCollectorSpec extends Specification {
 
     ProjectBuilder builder = new ProjectBuilder()
@@ -67,5 +70,166 @@ class LicenseDataCollectorSpec extends Specification {
         then:
         result.licenses*.name == ["Apache License, Version 2.0", "Apache License, Version 2.0"]
         result.licenses*.url == [null, "https://www.apache.org/licenses/LICENSE-2.0"]
+    }
+
+    def "keep manifest-license when name/url not matches a existing licenses name or url"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                    }
+                    manifest("mani1") {
+                        license("Apache 2.0")
+                    }
+                    manifest("mani2") {
+                        license("https://someUrl")
+                    }
+                }
+            }
+        }
+
+        when:
+        ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
+        def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
+
+        then:
+        json(result) == """{
+    "moduleUrls": [
+        "http://dummy-mani-url",
+        "http://dummy-pom-project-url"
+    ],
+    "licenses": [
+        {
+            "comments": null,
+            "distribution": null,
+            "url": "https://someUrl",
+            "name": null
+        },
+        {
+            "comments": null,
+            "distribution": null,
+            "url": null,
+            "name": "Apache 2.0"
+        },
+        {
+            "comments": "A business-friendly OSS license",
+            "distribution": "repo",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+        }
+    ]
+}"""
+    }
+
+    def "remove manifest-license when name/url matches a existing licenses name or url"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                    }
+                    manifest("mani1") {
+                        license(APACHE2_LICENSE().name)
+                    }
+                    manifest("mani2") {
+                        license(APACHE2_LICENSE().url)
+                    }
+                }
+            }
+        }
+
+        when:
+        ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
+        def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
+
+        then:
+        json(result) == """{
+    "moduleUrls": [
+        "http://dummy-mani-url",
+        "http://dummy-pom-project-url"
+    ],
+    "licenses": [
+        {
+            "comments": "A business-friendly OSS license",
+            "distribution": "repo",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+        }
+    ]
+}"""
+    }
+
+    def "keep license-file-license when name not matches a existing licenses name or url"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                    }
+                    licenseFiles {
+                        licenseFileDetails(file: "apache2-license.txt", license: "Apache 2.0", licenseUrl: APACHE2_LICENSE().url)
+                    }
+                }
+            }
+        }
+        when:
+        ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
+        def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
+
+        then:
+        json(result) == """{
+    "moduleUrls": [
+        "http://dummy-pom-project-url"
+    ],
+    "licenses": [
+        {
+            "comments": null,
+            "distribution": null,
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache 2.0"
+        },
+        {
+            "comments": "A business-friendly OSS license",
+            "distribution": "repo",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+        }
+    ]
+}"""
+    }
+
+    def "remove license-file-license when name matches a existing licenses name or url"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    pom("pom1") {
+                        license(APACHE2_LICENSE())
+                    }
+                    licenseFiles {
+                        licenseFileDetails(file: "apache2-license.txt", license: APACHE2_LICENSE().name, licenseUrl: APACHE2_LICENSE().url)
+                        licenseFileDetails(file: "apache2-license.txt", license: APACHE2_LICENSE().name, licenseUrl: "http://some-url")
+                    }
+                }
+            }
+        }
+        when:
+        ModuleData moduleData = projectData.configurations*.dependencies.flatten().first()
+        def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
+
+        then:
+        json(result) == """{
+    "moduleUrls": [
+        "http://dummy-pom-project-url"
+    ],
+    "licenses": [
+        {
+            "comments": "A business-friendly OSS license",
+            "distribution": "repo",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+            "name": "Apache License, Version 2.0"
+        }
+    ]
+}"""
     }
 }


### PR DESCRIPTION
In a multi-license-json, still a lot of unnecessary dependencies from the manifest appears, where the URL is null, but right after it, the "full" pom-license has the information as well:

```
            "moduleLicenses": [
                {
                    "moduleLicense": "Apache License, Version 2.0",
                    "moduleLicenseUrl": null
                },
                {
                    "moduleLicense": "Apache License, Version 2.0",
                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
                }
            ]
```

Now, pom-licenses are preferred, and mannifest-licenses are not included in the multi-license-info, when there  is a pom with the appropriate name/url. Also pom is prefered over license-file-licenses.

Note that the actual `ProjectData` are not affected, only the data for rendering Json, CSV, XML are affected.