### PR TITLE
Make model data ordered

### DIFF
--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -16,39 +16,38 @@
 package com.github.jk1.license
 
 import groovy.transform.Canonical
+import groovy.transform.Sortable
 import org.gradle.api.Project
 
 @Canonical
 class ProjectData {
     Project project
-    Set<ConfigurationData> configurations = new HashSet<ConfigurationData>()
+    Set<ConfigurationData> configurations = new TreeSet<ConfigurationData>()
     List<ImportedModuleBundle> importedModules = new ArrayList<ImportedModuleBundle>()
     Set<ModuleData> getAllDependencies() {
-        new HashSet<ModuleData>(configurations.collect { it.dependencies }.flatten())
+        new TreeSet<ModuleData>(configurations*.dependencies.flatten())
     }
 }
 
+@Sortable(includes = "name")
 @Canonical
 class ConfigurationData {
     String name
-    Set<ModuleData> dependencies = new HashSet<ModuleData>()
+    Set<ModuleData> dependencies = new TreeSet<ModuleData>()
 }
 
+@Sortable(includes = ["group", "name", "version"])
 @Canonical
-class ModuleData implements Comparable<ModuleData> {
+class ModuleData {
     String group, name, version
-    Set<ManifestData> manifests = new HashSet<ManifestData>()
+    Set<ManifestData> manifests = new TreeSet<ManifestData>()
     Set<LicenseFileData> licenseFiles = new HashSet<LicenseFileData>()
     Set<PomData> poms = new HashSet<PomData>()
 
     boolean isEmpty() { manifests.isEmpty() && poms.isEmpty() && licenseFiles.isEmpty() }
-
-    @Override
-    int compareTo(ModuleData o) {
-        group <=> o.group ?: name <=> o.name ?: version <=> o.version
-    }
 }
 
+@Sortable
 @Canonical
 class ManifestData {
     String name, version, description, vendor, license, url
@@ -58,29 +57,27 @@ class ManifestData {
 @Canonical
 class PomData {
     String name, description, projectUrl, inceptionYear
-    Set<License> licenses = new HashSet<License>()
+    Set<License> licenses = new TreeSet<License>()
     PomOrganization organization
-    Set<PomDeveloper> developers
+    Set<PomDeveloper> developers = new TreeSet<PomDeveloper>()
 }
 
+@Sortable
 @Canonical
 class PomOrganization {
     String name, url
 }
 
+@Sortable
 @Canonical
 class PomDeveloper {
     String name, email, url
 }
 
+@Sortable(includes = "name")
 @Canonical
 class License {
     String name, url, distribution, comments
-
-    @Override
-    boolean equals(Object other) {
-        name == other.name
-    }
 }
 
 @Canonical
@@ -95,6 +92,7 @@ class LicenseFileData {
     Collection<LicenseFileDetails> fileDetails = []
 }
 
+@Sortable
 @Canonical
 class LicenseFileDetails {
     String file
@@ -105,9 +103,10 @@ class LicenseFileDetails {
 @Canonical
 class ImportedModuleBundle {
     String name
-    Collection<ImportedModuleData> modules = new HashSet<ImportedModuleData>()
+    Collection<ImportedModuleData> modules = new TreeSet<ImportedModuleData>()
 }
 
+@Sortable
 @Canonical
 class ImportedModuleData {
     String name

--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -36,16 +36,17 @@ class ModuleReader {
         dependency.moduleArtifacts.each { ResolvedArtifact artifact ->
             LOGGER.info("Processing artifact: $artifact ($artifact.file)")
             if (artifact.file.exists()){
-                data.poms << pomReader.readPomData(project, artifact)
-                data.manifests << manifestReader.readManifestData(project, artifact)
-                data.licenseFiles << filesReader.read(project, artifact)
+                def pom = pomReader.readPomData(project, artifact)
+                def manifest = manifestReader.readManifestData(project, artifact)
+                def licenseFile = filesReader.read(project, artifact)
+
+                if (pom) data.poms << pom
+                if (manifest) data.manifests << manifest
+                if (licenseFile) data.licenseFiles << licenseFile
             } else {
                 LOGGER.info("Skipping artifact file $artifact.file as it does not exist")
             }
         }
-        data.poms = data.poms - null
-        data.manifests = data.manifests - null
-        data.licenseFiles = data.licenseFiles - null
         data
     }
 }

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -176,13 +176,14 @@ class PomReader {
         pomData.projectUrl = rootPom.url?.text()
         pomData.inceptionYear = rootPom.inceptionYear?.text()
 
-        pomData.developers = rootPom.developers?.developer?.collect { GPathResult developer ->
+        def developers = rootPom.developers?.developer?.collect { GPathResult developer ->
             new PomDeveloper(
                 name: developer.name?.text(),
                 email: developer.email?.text(),
                 url: developer.url?.text()
             )
         }
+        if (developers) pomData.developers.addAll(developers)
 
         allPoms.reverse().each { pom ->
             def organizationName = pom.organization?.name?.text()

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -41,7 +41,7 @@ class ProjectReader {
         configurationsToScan.addAll(getAllExtendedConfigurations(configurationsToScan))
 
         LOGGER.info("Configurations: " + configurationsToScan.join(','))
-        data.configurations = readConfigurationData(configurationsToScan, project)
+        data.configurations.addAll(readConfigurationData(configurationsToScan, project))
         return data
     }
 

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -74,8 +74,7 @@ class ProjectBuilder extends BuilderSupport {
         ProjectData projectData = (ProjectData)current
 
         def config = new ConfigurationData(
-            name: id,
-            dependencies: [ ]
+            name: id
         )
         projectData.configurations << config
         config
@@ -110,10 +109,7 @@ class ProjectBuilder extends BuilderSupport {
         ConfigurationData configurationData = (ConfigurationData)current
 
         def module = new ModuleData(
-            group: "dummy-group", name: id, version: "0.0.1",
-            manifests: [],
-            licenseFiles: [],
-            poms: []
+            group: "dummy-group", name: id, version: "0.0.1"
         )
 
         configurationData.dependencies << module
@@ -129,9 +125,7 @@ class ProjectBuilder extends BuilderSupport {
             inceptionYear: "dummy-pom-inception-year",
             organization: new PomOrganization(
                 name: "dummy-pom-org-name", url: "http://dummy-pom-org-url"
-            ),
-            licenses: [],
-            developers: []
+            )
         )
 
         module.poms << pom

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
@@ -102,7 +102,7 @@ class ProjectBuilderSpec extends Specification {
 
         data.configurations*.dependencies.flatten().poms.flatten().find { it.name == "pom1" }.licenses as List == [APACHE2_LICENSE()]
         data.configurations*.dependencies.flatten().poms.flatten().find { it.name == "pom2" }.licenses as List == [MIT_LICENSE()]
-        data.configurations*.dependencies.flatten().poms.flatten().find { it.name == "pom3" }.licenses as List == [MIT_LICENSE(), LGPL_LICENSE()]
+        data.configurations*.dependencies.flatten().poms.flatten().find { it.name == "pom3" }.licenses as List == [LGPL_LICENSE(), MIT_LICENSE()]
 
         data.importedModules.isEmpty()
     }

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -90,43 +90,6 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
     {
         "dependencies": [
             {
-                "group": "org.jetbrains",
-                "manifests": [
-                    {
-                        "vendor": null,
-                        "hasPackagedLicense": false,
-                        "version": null,
-                        "license": null,
-                        "description": null,
-                        "url": null,
-                        "name": null
-                    }
-                ],
-                "version": "16.0.1",
-                "poms": [
-                    {
-                        "inceptionYear": "",
-                        "projectUrl": "https://github.com/JetBrains/java-annotations",
-                        "description": "A set of annotations used for code inspection support and code documentation.",
-                        "name": "JetBrains Java Annotations",
-                        "organization": null,
-                        "licenses": [
-                            {
-                                "comments": "",
-                                "distribution": "repo",
-                                "url": "http://www.apache.org/license/LICENSE-2.0.txt",
-                                "name": "The Apache Software License, Version 2.0"
-                            }
-                        ]
-                    }
-                ],
-                "licenseFiles": [
-                    
-                ],
-                "empty": false,
-                "name": "annotations"
-            },
-            {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
@@ -182,6 +145,43 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 ],
                 "empty": false,
                 "name": "commons-lang3"
+            },
+            {
+                "group": "org.jetbrains",
+                "manifests": [
+                    {
+                        "vendor": null,
+                        "hasPackagedLicense": false,
+                        "version": null,
+                        "license": null,
+                        "description": null,
+                        "url": null,
+                        "name": null
+                    }
+                ],
+                "version": "16.0.1",
+                "poms": [
+                    {
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/JetBrains/java-annotations",
+                        "description": "A set of annotations used for code inspection support and code documentation.",
+                        "name": "JetBrains Java Annotations",
+                        "organization": null,
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/license/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    
+                ],
+                "empty": false,
+                "name": "annotations"
             }
         ],
         "name": "forTesting1"

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -263,63 +263,6 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
     {
         "dependencies": [
             {
-                "group": "org.ehcache",
-                "manifests": [
-                    {
-                        "vendor": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
-                        "hasPackagedLicense": true,
-                        "version": "3.3.1",
-                        "license": "LICENSE",
-                        "description": "Ehcache is an open-source caching library, compliant with the JSR-107 standard.",
-                        "url": "ehcache-3.3.1.jar/LICENSE.html",
-                        "name": "ehcache 3"
-                    }
-                ],
-                "version": "3.3.1",
-                "poms": [
-                    {
-                        "inceptionYear": "",
-                        "projectUrl": "http://ehcache.org",
-                        "description": "End-user ehcache3 jar artifact",
-                        "name": "Ehcache",
-                        "organization": {
-                            "url": "http://terracotta.org",
-                            "name": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc."
-                        },
-                        "licenses": [
-                            {
-                                "comments": "",
-                                "distribution": "repo",
-                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
-                                "name": "The Apache Software License, Version 2.0"
-                            }
-                        ]
-                    }
-                ],
-                "licenseFiles": [
-                    {
-                        "fileDetails": [
-                            {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "ehcache-3.3.1.jar/LICENSE",
-                                "license": "Apache License, Version 2.0"
-                            },
-                            {
-                                "licenseUrl": null,
-                                "file": "ehcache-3.3.1.jar/NOTICE",
-                                "license": null
-                            }
-                        ],
-                        "files": [
-                            "ehcache-3.3.1.jar/LICENSE",
-                            "ehcache-3.3.1.jar/NOTICE"
-                        ]
-                    }
-                ],
-                "empty": false,
-                "name": "ehcache"
-            },
-            {
                 "group": "aopalliance",
                 "manifests": [
                     {
@@ -357,68 +300,28 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "name": "aopalliance"
             },
             {
-                "group": "org.slf4j",
+                "group": "commons-logging",
                 "manifests": [
                     {
-                        "vendor": "SLF4J.ORG",
+                        "vendor": "Apache Software Foundation",
                         "hasPackagedLicense": false,
-                        "version": "1.7.7",
-                        "license": null,
-                        "description": "The slf4j API",
-                        "url": null,
-                        "name": "slf4j-api"
-                    }
-                ],
-                "version": "1.7.7",
-                "poms": [
-                    {
-                        "inceptionYear": "",
-                        "projectUrl": "http://www.slf4j.org",
-                        "description": "The slf4j API",
-                        "name": "SLF4J API Module",
-                        "organization": {
-                            "url": "http://www.qos.ch",
-                            "name": "QOS.ch"
-                        },
-                        "licenses": [
-                            {
-                                "comments": "",
-                                "distribution": "repo",
-                                "url": "http://www.opensource.org/licenses/mit-license.php",
-                                "name": "MIT License"
-                            }
-                        ]
-                    }
-                ],
-                "licenseFiles": [
-                    
-                ],
-                "empty": false,
-                "name": "slf4j-api"
-            },
-            {
-                "group": "org.springframework",
-                "manifests": [
-                    {
-                        "vendor": null,
-                        "hasPackagedLicense": false,
-                        "version": "3.2.3.RELEASE",
+                        "version": "1.1.1",
                         "license": null,
                         "description": null,
                         "url": null,
-                        "name": "spring-core"
+                        "name": "Jakarta Commons Logging"
                     }
                 ],
-                "version": "3.2.3.RELEASE",
+                "version": "1.1.1",
                 "poms": [
                     {
-                        "inceptionYear": "",
-                        "projectUrl": "https://github.com/SpringSource/spring-framework",
-                        "description": "Spring Core",
-                        "name": "Spring Core",
+                        "inceptionYear": "2001",
+                        "projectUrl": "http://commons.apache.org/logging",
+                        "description": "Commons Logging is a thin adapter allowing configurable bridging to other,\\n    well known logging systems.",
+                        "name": "Commons Logging",
                         "organization": {
-                            "url": "http://springsource.org/spring-framework",
-                            "name": "SpringSource"
+                            "url": "http://www.apache.org/",
+                            "name": "The Apache Software Foundation"
                         },
                         "licenses": [
                             {
@@ -435,23 +338,23 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "commons-logging-1.1.1.jar/META-INF/LICENSE",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
-                                "license": "Apache License, Version 2.0"
+                                "licenseUrl": null,
+                                "file": "commons-logging-1.1.1.jar/META-INF/NOTICE",
+                                "license": null
                             }
                         ],
                         "files": [
-                            "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
-                            "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt"
+                            "commons-logging-1.1.1.jar/META-INF/LICENSE",
+                            "commons-logging-1.1.1.jar/META-INF/NOTICE"
                         ]
                     }
                 ],
                 "empty": false,
-                "name": "spring-core"
+                "name": "commons-logging"
             },
             {
                 "group": "org.apache.commons",
@@ -511,6 +414,103 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "name": "commons-lang3"
             },
             {
+                "group": "org.ehcache",
+                "manifests": [
+                    {
+                        "vendor": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
+                        "hasPackagedLicense": true,
+                        "version": "3.3.1",
+                        "license": "LICENSE",
+                        "description": "Ehcache is an open-source caching library, compliant with the JSR-107 standard.",
+                        "url": "ehcache-3.3.1.jar/LICENSE.html",
+                        "name": "ehcache 3"
+                    }
+                ],
+                "version": "3.3.1",
+                "poms": [
+                    {
+                        "inceptionYear": "",
+                        "projectUrl": "http://ehcache.org",
+                        "description": "End-user ehcache3 jar artifact",
+                        "name": "Ehcache",
+                        "organization": {
+                            "url": "http://terracotta.org",
+                            "name": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc."
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    {
+                        "fileDetails": [
+                            {
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "ehcache-3.3.1.jar/LICENSE",
+                                "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "ehcache-3.3.1.jar/NOTICE",
+                                "license": null
+                            }
+                        ],
+                        "files": [
+                            "ehcache-3.3.1.jar/LICENSE",
+                            "ehcache-3.3.1.jar/NOTICE"
+                        ]
+                    }
+                ],
+                "empty": false,
+                "name": "ehcache"
+            },
+            {
+                "group": "org.slf4j",
+                "manifests": [
+                    {
+                        "vendor": "SLF4J.ORG",
+                        "hasPackagedLicense": false,
+                        "version": "1.7.7",
+                        "license": null,
+                        "description": "The slf4j API",
+                        "url": null,
+                        "name": "slf4j-api"
+                    }
+                ],
+                "version": "1.7.7",
+                "poms": [
+                    {
+                        "inceptionYear": "",
+                        "projectUrl": "http://www.slf4j.org",
+                        "description": "The slf4j API",
+                        "name": "SLF4J API Module",
+                        "organization": {
+                            "url": "http://www.qos.ch",
+                            "name": "QOS.ch"
+                        },
+                        "licenses": [
+                            {
+                                "comments": "",
+                                "distribution": "repo",
+                                "url": "http://www.opensource.org/licenses/mit-license.php",
+                                "name": "MIT License"
+                            }
+                        ]
+                    }
+                ],
+                "licenseFiles": [
+                    
+                ],
+                "empty": false,
+                "name": "slf4j-api"
+            },
+            {
                 "group": "org.springframework",
                 "manifests": [
                     {
@@ -568,28 +568,28 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "name": "spring-beans"
             },
             {
-                "group": "commons-logging",
+                "group": "org.springframework",
                 "manifests": [
                     {
-                        "vendor": "Apache Software Foundation",
+                        "vendor": null,
                         "hasPackagedLicense": false,
-                        "version": "1.1.1",
+                        "version": "3.2.3.RELEASE",
                         "license": null,
                         "description": null,
                         "url": null,
-                        "name": "Jakarta Commons Logging"
+                        "name": "spring-core"
                     }
                 ],
-                "version": "1.1.1",
+                "version": "3.2.3.RELEASE",
                 "poms": [
                     {
-                        "inceptionYear": "2001",
-                        "projectUrl": "http://commons.apache.org/logging",
-                        "description": "Commons Logging is a thin adapter allowing configurable bridging to other,\\n    well known logging systems.",
-                        "name": "Commons Logging",
+                        "inceptionYear": "",
+                        "projectUrl": "https://github.com/SpringSource/spring-framework",
+                        "description": "Spring Core",
+                        "name": "Spring Core",
                         "organization": {
-                            "url": "http://www.apache.org/",
-                            "name": "The Apache Software Foundation"
+                            "url": "http://springsource.org/spring-framework",
+                            "name": "SpringSource"
                         },
                         "licenses": [
                             {
@@ -606,23 +606,23 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-logging-1.1.1.jar/META-INF/LICENSE",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
-                                "licenseUrl": null,
-                                "file": "commons-logging-1.1.1.jar/META-INF/NOTICE",
-                                "license": null
+                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "license": "Apache License, Version 2.0"
                             }
                         ],
                         "files": [
-                            "commons-logging-1.1.1.jar/META-INF/LICENSE",
-                            "commons-logging-1.1.1.jar/META-INF/NOTICE"
+                            "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                            "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt"
                         ]
                     }
                 ],
                 "empty": false,
-                "name": "commons-logging"
+                "name": "spring-core"
             },
             {
                 "group": "org.springframework",

--- a/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
@@ -83,8 +83,8 @@ class LicenseDataCollectorSpec extends Specification {
         def result = LicenseDataCollector.multiModuleLicenseInfo(moduleData)
 
         then:
-        result.licenses*.name == ["Apache License, Version 2.0", "Apache License, Version 2.0"]
-        result.licenses*.url == [null, "https://www.apache.org/licenses/LICENSE-2.0"]
+        result.licenses*.name == ["Apache License, Version 2.0"]
+        result.licenses*.url == ["https://www.apache.org/licenses/LICENSE-2.0"]
     }
 
     def "keep manifest-license when name/url not matches a existing licenses name or url"() {


### PR DESCRIPTION
With the `HashMap` as backing data structure in most of the Model-classes, the ordering is quite unpredictable, because the hash-code changes on every change of any data. So now, the backing data-structure is `TreeSet`, which is sorted. All the model classes also are now `Comparable` to make the `TreeSet` working. This makes the output more stable and resilient to minor changes in not-relevent fields (e.g. in the developers-field)