### PR TITLE
Multiple licenses within one file

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/ReduceDuplicateLicensesFilter.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/ReduceDuplicateLicensesFilter.groovy
@@ -20,16 +20,16 @@ import com.github.jk1.license.PomData
 import com.github.jk1.license.ProjectData
 
 class ReduceDuplicateLicensesFilter implements DependencyFilter {
-    
+
     @Override
     ProjectData filter(ProjectData projectData) {
         // remove pom duplicates
-        projectData.allDependencies*.poms.flatten().forEach { PomData pom ->
+        projectData.configurations*.dependencies.flatten().poms.flatten().forEach { PomData pom ->
             pom.licenses = pom.licenses.unique()
         }
 
         // remove license-file duplicates
-        projectData.allDependencies*.licenseFiles.flatten().forEach { LicenseFileData files ->
+        projectData.configurations*.dependencies.flatten().licenseFiles.flatten().forEach { LicenseFileData files ->
             files.fileDetails = files.fileDetails.unique()
             files.files = files.files.unique()
         }

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -70,6 +70,15 @@ class ProjectBuilder extends BuilderSupport {
             project: GRADLE_PROJECT()
         )
     }
+
+    // allows to create multiple configurations with only defining the child-structure once.
+    def configurations(List<String> configNames, Closure<ConfigurationData> block) {
+        configNames.forEach { name ->
+            block.delegate = this
+            block(name)
+        }
+    }
+
     private ConfigurationData addConfiguration(String id) {
         ProjectData projectData = (ProjectData)current
 

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -176,7 +176,7 @@ class ProjectBuilder extends BuilderSupport {
 
         def details = new LicenseFileDetails(map)
 
-        licenseFileData.files << details.file
+        if (!licenseFileData.files.contains(details.file)) licenseFileData.files << details.file
         licenseFileData.fileDetails << details
         details
     }

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -70,19 +70,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache 2")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("Apache 2")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache License, Version 2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("Apache License, Version 2.0")
+                        }
                     }
                 }
             }
@@ -103,19 +107,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache License, Version 2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("Apache License, Version 2.0")
+                        }
                     }
                 }
             }
@@ -136,33 +144,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "Apache 2")
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "Apache 2")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), name: "Apache 2")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
@@ -183,33 +181,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache 2")
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache 2")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("Apache 2")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache License, Version 2.0")
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    manifest("mani1") {
-                        license("Apache License, Version 2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        manifest("mani1") {
+                            license("Apache License, Version 2.0")
+                        }
                     }
                 }
             }
@@ -230,33 +218,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license")
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                }
-            }
-            configuration("test") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -277,19 +255,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache 2")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache 2")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -310,19 +292,23 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -343,22 +329,26 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "The Apache 2 License") // should stay
-                        license(APACHE2_LICENSE(), name: "Apache 2.0") // should be unified with the last one
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), name: "The Apache 2 License") // should stay
+                            license(APACHE2_LICENSE(), name: "Apache 2.0") // should be unified with the last one
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "The Apache 2 License")
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), name: "The Apache 2 License")
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
@@ -379,20 +369,24 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }
@@ -417,27 +411,31 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(name: "name1", url: "url1")
-                        license(name: "name2", url: "url2")
-                        license(name: "name3", url: "url3")
-                        license(name: "name4", url: "url4")
-                        license(name: "name5", url: "url5")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "name1", url: "url1")
+                            license(name: "name2", url: "url2")
+                            license(name: "name3", url: "url3")
+                            license(name: "name4", url: "url4")
+                            license(name: "name5", url: "url5")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(name: "Apache License, Version 2.0", url: "url1")
-                        license(name: "Apache Software License, Version 1.1", url: "url2")
-                        license(name: "name3", url: "https://www.apache.org/licenses/LICENSE-2.0")
-                        license(name: "name4", url: "https://www.apache.org/licenses/LICENSE-2.0")
-                        license(name: "name5", url: "url5")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "Apache License, Version 2.0", url: "url1")
+                            license(name: "Apache Software License, Version 1.1", url: "url2")
+                            license(name: "name3", url: "https://www.apache.org/licenses/LICENSE-2.0")
+                            license(name: "name4", url: "https://www.apache.org/licenses/LICENSE-2.0")
+                            license(name: "name5", url: "url5")
+                        }
                     }
                 }
             }
@@ -462,23 +460,27 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(name: "name1", url: "url1")
-                        license(name: "name2", url: "url2")
-                        license(name: "name3", url: "url3")
-                        license(name: "name4", url: "url4")
-                        license(name: "name5", url: "url5")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "name1", url: "url1")
+                            license(name: "name2", url: "url2")
+                            license(name: "name3", url: "url3")
+                            license(name: "name4", url: "url4")
+                            license(name: "name5", url: "url5")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -495,21 +497,27 @@ class LicenseBundleNormalizerSpec extends Specification {
         normalizerFile << """}"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), url: "different url") // should be normalized because name matches the bundle-name
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")   // should stay, because name is different
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), url: "different url")
+                            // should be normalized because name matches the bundle-name
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            // should stay, because name is different
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                        }
                     }
                 }
             }
@@ -526,21 +534,27 @@ class LicenseBundleNormalizerSpec extends Specification {
         normalizerFile << """}"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "different name") // should be normalized because url matches the bundle-url
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")   // should stay, because url is different
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), name: "different name")
+                            // should be normalized because url matches the bundle-url
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            // should stay, because url is different
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                        }
                     }
                 }
             }
@@ -557,23 +571,27 @@ class LicenseBundleNormalizerSpec extends Specification {
         normalizerFile << """}"""
 
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), url: "different url")
-                        license(APACHE2_LICENSE(), name: "different name")
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), url: "different url")
+                            license(APACHE2_LICENSE(), name: "different name")
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), url: "different url")
-                        license(APACHE2_LICENSE(), name: "different name")
-                        license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), url: "different url")
+                            license(APACHE2_LICENSE(), name: "different name")
+                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                        }
                     }
                 }
             }

--- a/src/test/groovy/com/github/jk1/license/filter/ReduceDuplicateLicensesFilterSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/ReduceDuplicateLicensesFilterSpec.groovy
@@ -29,11 +29,13 @@ class ReduceDuplicateLicensesFilterSpec extends Specification {
     def "when two licenses are equal in one pom, they should be unified"() {
         // add two configuration with slightly different name (to avoid HashMap swallow one)
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), name: "Apache 2")
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), name: "Apache 2")
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
@@ -43,10 +45,12 @@ class ReduceDuplicateLicensesFilterSpec extends Specification {
             it.name = APACHE2_LICENSE().name
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
@@ -62,22 +66,26 @@ class ReduceDuplicateLicensesFilterSpec extends Specification {
     def "when two license names in a pom are equal, they should be unified, even if other details differ"() {
         // add two configuration with slightly different name (to avoid HashMap swallow one)
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                        license(APACHE2_LICENSE(), url: "someting else")
-                        license(APACHE2_LICENSE(), distribution: "someting else")
-                        license(APACHE2_LICENSE(), comments: "someting else")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                            license(APACHE2_LICENSE(), url: "someting else")
+                            license(APACHE2_LICENSE(), distribution: "someting else")
+                            license(APACHE2_LICENSE(), comments: "someting else")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
                     }
                 }
             }
@@ -92,20 +100,24 @@ class ReduceDuplicateLicensesFilterSpec extends Specification {
 
     def "when two licenses files are equals, they should be unified"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }
         }
         ProjectData expected = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", licenseUrl: "http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
                     }
                 }
             }

--- a/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/JsonReportRendererSpec.groovy
@@ -46,31 +46,33 @@ class JsonReportRendererSpec extends Specification {
         new File(testProjectDir.root, "apache2.license") << apache2LicenseFile.text
 
         projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE(), url: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), url: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0")
+                        }
                     }
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                    manifest("mani1") {
-                        license("Apache 2.0")
-                    }
-                }
-                module("mod2") {
-                    pom("pom2") {
-                        license(APACHE2_LICENSE())
-                    }
-                    pom("pom3") {
-                        license(APACHE2_LICENSE())
-                        license(MIT_LICENSE())
-                    }
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
-                    }
-                    manifest("mani1") {
-                        license("Apache 2.0")
+                    module("mod2") {
+                        pom("pom2") {
+                            license(APACHE2_LICENSE())
+                        }
+                        pom("pom3") {
+                            license(APACHE2_LICENSE())
+                            license(MIT_LICENSE())
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0")
+                        }
                     }
                 }
             }

--- a/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/LicenseDataCollectorSpec.groovy
@@ -29,8 +29,10 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "empty module info results in empty license info"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                    }
                 }
             }
         }
@@ -45,10 +47,12 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "after normalisation, all license files of all configurations are normalized"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -65,14 +69,16 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "duplicate licenses are sorted out"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
-                        license(name: "Apache License, Version 2.0", url: null)
-                    }
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
+                            license(name: "Apache License, Version 2.0", url: null)
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
                     }
                 }
             }
@@ -89,16 +95,18 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "keep manifest-license when name/url not matches a existing licenses name or url"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                    }
-                    manifest("mani1") {
-                        license("Apache 2.0")
-                    }
-                    manifest("mani2") {
-                        license("https://someUrl")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0")
+                        }
+                        manifest("mani2") {
+                            license("https://someUrl")
+                        }
                     }
                 }
             }
@@ -139,16 +147,18 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "remove manifest-license when name/url matches a existing licenses name or url"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                    }
-                    manifest("mani1") {
-                        license(APACHE2_LICENSE().name)
-                    }
-                    manifest("mani2") {
-                        license(APACHE2_LICENSE().url)
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
+                        manifest("mani1") {
+                            license(APACHE2_LICENSE().name)
+                        }
+                        manifest("mani2") {
+                            license(APACHE2_LICENSE().url)
+                        }
                     }
                 }
             }
@@ -177,13 +187,15 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "keep license-file-license when name not matches a existing licenses name or url"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                    }
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: "Apache 2.0", licenseUrl: APACHE2_LICENSE().url)
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache 2.0", licenseUrl: APACHE2_LICENSE().url)
+                        }
                     }
                 }
             }
@@ -216,14 +228,16 @@ class LicenseDataCollectorSpec extends Specification {
 
     def "remove license-file-license when name matches a existing licenses name or url"() {
         ProjectData projectData = builder.project {
-            configuration("runtime") {
-                module("mod1") {
-                    pom("pom1") {
-                        license(APACHE2_LICENSE())
-                    }
-                    licenseFiles {
-                        licenseFileDetails(file: "apache2.license", license: APACHE2_LICENSE().name, licenseUrl: APACHE2_LICENSE().url)
-                        licenseFileDetails(file: "apache2.license", license: APACHE2_LICENSE().name, licenseUrl: "http://some-url")
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE())
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: APACHE2_LICENSE().name, licenseUrl: APACHE2_LICENSE().url)
+                            licenseFileDetails(file: "apache2.license", license: APACHE2_LICENSE().name, licenseUrl: "http://some-url")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The dependency  `javax.annotation:javax.annotation-api:1.3.2` contains only one license, but within that license entry, two different licenses are addressed: CDDL + GPL

The PR allows to normalize such entries, by splitting them up. This is done by applying all matching transformation rules, instead of just apply the first one.