### PR TITLE
Allow usage of exact strings in the normalization rule

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -148,7 +148,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
     private List<NormalizerTransformationRule> findMatchingRulesForName(String name) {
         return normalizerConfig.transformationRules
-            .findAll { it.licenseNamePattern && name =~ it.licenseNamePattern }
+            .findAll { it.licenseNamePattern && (name == it.licenseNamePattern || name =~ it.licenseNamePattern) }
     }
     private List<NormalizerTransformationRule> findMatchingRulesForUrl(String url) {
         return normalizerConfig.transformationRules

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -725,6 +725,49 @@ class LicenseBundleNormalizerSpec extends Specification {
         json(result) == json(expected)
     }
 
+    def "when the normalization rules are evaluated for pom and manifest, before the regular expression check, a exact match should be done"() {
+        normalizerFile << """,
+            "transformationRules" : [
+                { "bundleName" : "apache2", "licenseNamePattern" : "Apache 2.0 + friends" }
+              ]
+            }"""
+
+        ProjectData projectData = builder.project {
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "Apache 2.0 + friends")
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0 + friends")
+                        }
+                    }
+                }
+            }
+        }
+        ProjectData expected = builder.project {
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        manifest("mani1") {
+                            license("Apache License, Version 2.0")
+                        }
+                    }
+                }
+            }
+        }
+
+        when:
+        def result = newNormalizer().filter(projectData)
+
+        then:
+        json(result) == json(expected)
+    }
+
     private LicenseBundleNormalizer newNormalizer(boolean createDefaultTransformationRules = false) {
         new LicenseBundleNormalizer(bundlePath: normalizerFile.absolutePath, createDefaultTransformationRules: createDefaultTransformationRules)
     }


### PR DESCRIPTION
The license names of normalisation rules are firstly checked with
an exact match. Only if this match fails, the name is treated as a
regular expression.