### PR TITLE
Cddl license

### DIFF
--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -105,15 +105,15 @@ class LicenseFilesReader {
         def text = new File(config.outputDir, file).text
         if (text.contains('Apache License, Version 2.0')) {
             moduleLicense = 'Apache License, Version 2.0'
-            moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'
+            moduleLicenseUrl = 'https://www.apache.org/licenses/LICENSE-2.0'
         }
         if (text.contains('Apache Software License, Version 1.1')) {
             moduleLicense = 'Apache Software License, Version 1.1'
-            moduleLicenseUrl = 'http://www.apache.org/licenses/LICENSE-1.1'
+            moduleLicenseUrl = 'https://www.apache.org/licenses/LICENSE-1.1'
         }
         if (text.contains('CDDL')) {
             moduleLicense = 'COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0'
-            moduleLicenseUrl = 'http://opensource.org/licenses/CDDL-1.0'
+            moduleLicenseUrl = 'https://opensource.org/licenses/CDDL-1.0'
         }
 
         new LicenseFileDetails(file: file, license: moduleLicense, licenseUrl: moduleLicenseUrl)

--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -21,6 +21,7 @@
     { "bundleName" : "bsd-3",   "licenseName" : "The 3-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-3-Clause" },
     { "bundleName" : "cc0",     "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "https://repository.jboss.org/licenses/cc0-1.0.txt" },
     { "bundleName" : "cddl1",   "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0", "licenseUrl" : "https://oss.oracle.com/licenses/CDDL" },
+    { "bundleName" : "cddl1.1", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1", "licenseUrl" : "https://oss.oracle.com/licenses/CDDL-1.1" },
     { "bundleName" : "cpl-1.0", "licenseName" : "Common Public License - v 1.0", "licenseUrl" : "https://www.eclipse.org/legal/cpl-v10.html" },
     { "bundleName" : "epl1",    "licenseName" : "Eclipse Public License - v 1.0", "licenseUrl" : "http://www.eclipse.org/legal/epl-v10.html" },
     { "bundleName" : "epl2",    "licenseName" : "Eclipse Public License - v 2.0", "licenseUrl" : "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt" },

--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -15,12 +15,12 @@
  */
 {
   "bundles" : [
-    { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-1.1" },
-    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-1.1" },
+    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-2.0" },
     { "bundleName" : "bsd-2",   "licenseName" : "The 2-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-2-Clause" },
     { "bundleName" : "bsd-3",   "licenseName" : "The 3-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-3-Clause" },
-    { "bundleName" : "cc0",     "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "http://repository.jboss.org/licenses/cc0-1.0.txt" },
-    { "bundleName" : "cddl1",   "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0", "licenseUrl" : "http://opensource.org/licenses/CDDL-1.0" },
+    { "bundleName" : "cc0",     "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "https://repository.jboss.org/licenses/cc0-1.0.txt" },
+    { "bundleName" : "cddl1",   "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0", "licenseUrl" : "https://oss.oracle.com/licenses/CDDL" },
     { "bundleName" : "cpl-1.0", "licenseName" : "Common Public License - v 1.0", "licenseUrl" : "https://www.eclipse.org/legal/cpl-v10.html" },
     { "bundleName" : "epl1",    "licenseName" : "Eclipse Public License - v 1.0", "licenseUrl" : "http://www.eclipse.org/legal/epl-v10.html" },
     { "bundleName" : "epl2",    "licenseName" : "Eclipse Public License - v 2.0", "licenseUrl" : "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt" },
@@ -42,6 +42,6 @@
     { "bundleName" : "mit",     "licenseUrlPattern" : ".*www.opensource.org/licenses/mit-license.php" },
     { "bundleName" : "apache2", "licenseFileContentPattern" : ".*Apache License, Version 2.0.*" },
     { "bundleName" : "apache1", "licenseFileContentPattern" : ".*Apache Software License, Version 1.1.*" },
-    { "bundleName" : "cddl1",   "licenseFileContentPattern" : ".*CDDL.*" }
+    { "bundleName" : "cddl1",   "licenseFileContentPattern" : ".*CDDL.*1.0" }
   ]
 }

--- a/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
+++ b/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
@@ -88,7 +88,7 @@ class PluginCompatibilityTest extends Specification {
                 },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         },

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -198,7 +198,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         },
@@ -211,7 +211,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         },
@@ -224,7 +224,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
                 }
             ]
         }

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -130,7 +130,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                                 "license": null
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -257,7 +257,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                                 "license": null
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -319,7 +319,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                                 "license": null
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -431,7 +431,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                                 "license": null
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             }

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -86,7 +86,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "license": null
             },
             {
-                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
             }
@@ -352,7 +352,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-logging-1.1.1.jar/META-INF/LICENSE",
                                 "license": "Apache License, Version 2.0"
                             },
@@ -414,7 +414,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                                 "license": null
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -466,7 +466,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "ehcache-3.3.1.jar/LICENSE",
                                 "license": "Apache License, Version 2.0"
                             },
@@ -563,12 +563,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -620,12 +620,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             }
@@ -677,12 +677,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
-                                "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
+                                "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             }


### PR DESCRIPTION
Prefer https over http 
and add the cddl 1.1 license to the default license bundle