### PR TITLE
Do not duplicate header

### DIFF
--- a/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
@@ -40,8 +40,6 @@ class TextReportRenderer implements ReportRenderer{
         config = project.licenseReport
         output = new File(config.outputDir, fileName)
         output.text = """
-Dependency License Report for $project.name
-
 Dependency License Report for $project.name ${if (!'unspecified'.equals(project.version)) project.version else ''}
 
 """


### PR DESCRIPTION
Currently the Dependency License Report for <project> is printed twice which looks odd especially if no version is set.