### PR TITLE
Add support for checking if all dependency licenses are allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ licenseReport {
     // Set importers to import any external dependency information, i.e. from npm.
     // Custom importer should implement DependencyDataImporter interface.
     importers = [new XmlReportImporter('Frontend dependencies', file(frontend_libs.xml))]
+    
+    // This is for the allowed-licenses-file in checkLicense Task
+    allowedLicensesFile = new File("$projectDir/config/allowed-licenses.json")
 }
 ```
 
@@ -331,4 +334,73 @@ licenseReport {
 ```
 
 The same technique can be used to create a filter or a renderer to support custom report formats.
+
+## Check Dependency Licenses
+
+This task is for checking dependencies/imported modules if their licenses are allowed to be used.  
+
+```batch
+./gradlew checkLicense
+```
+
+If there are not allowed licenses, the task will fail and a report like the following
+will be generated under `$outputDir` which you specified in the configuration:
+
+```json
+{
+  "dependenciesWithoutAllowedLicenses": [
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin:kotlin-stdlib",
+      "moduleVersion": "1.2.51"
+    },
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin:kotlin-stdlib-common",
+      "moduleVersion": "1.2.51"
+    }
+  ]
+}
+```
+
+### Allowed licenses file
+
+Defines which licenses are allowed to be used:
+
+```json
+{
+  "allowedLicenses": [
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin:kotlin-stdlib",
+      "moduleVersion": "1.2.60"
+    },
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": "org.jetbrains.kotlin*",
+      "moduleVersion": ".*"
+    },
+    {
+      "moduleLicense": "MIT License",
+      "moduleName": ".*"
+    },
+    {
+      "moduleLicense": "MIT License"
+    },
+    {
+      "moduleLicense": "MIT License",
+      "moduleName": ""
+    }
+  ]
+}
+
+```
+
+Also specify the allowed license file in the configuration:
+
+```groovy
+licenseReport {
+    allowedLicensesFile = new File("$projectDir/config/allowed-licenses.json")
+}
+```
 

--- a/src/main/groovy/com/github/jk1/license/CheckLicensePreparationTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/CheckLicensePreparationTask.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license
+
+import com.github.jk1.license.render.JsonReportRenderer
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+import static com.github.jk1.license.CheckLicenseTask.PROJECT_JSON_FOR_LICENSE_CHECKING_FILE
+
+class CheckLicensePreparationTask extends DefaultTask {
+
+    CheckLicensePreparationTask() {
+        group = "CheckingPreparation"
+        description = "Prepare for checkLicense"
+    }
+
+    @TaskAction
+    void checkPreparation() {
+        getProject().licenseReport.renderers +=
+            [ new JsonReportRenderer(PROJECT_JSON_FOR_LICENSE_CHECKING_FILE,false) ]
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/CheckLicenseTask.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license
+
+import com.github.jk1.license.check.LicenseChecker
+import org.gradle.api.DefaultTask
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+class CheckLicenseTask extends DefaultTask {
+    final static String PROJECT_JSON_FOR_LICENSE_CHECKING_FILE = "project-licenses-for-check-license-task.json"
+    final static String NOT_PASSED_DEPENDENCIES_FILE = "dependencies-without-allowed-license.json"
+
+    private Logger LOGGER = Logging.getLogger(CheckLicenseTask.class)
+    LicenseReportExtension config = getProject().licenseReport
+
+    CheckLicenseTask() {
+        group = 'Checking'
+        description = 'Check if License could be used'
+    }
+
+    @InputFile
+    File getAllowedLicenseFile() {
+        return config.allowedLicensesFile
+    }
+
+    @InputFile
+    File getProjectDependenciesData() {
+        return new File("${config.outputDir}/${PROJECT_JSON_FOR_LICENSE_CHECKING_FILE}")
+    }
+
+    @OutputFile
+    File getNotPassedDependenciesFile() {
+        new File("${config.outputDir}/$NOT_PASSED_DEPENDENCIES_FILE")
+    }
+
+    @TaskAction
+    void checkLicense() {
+        LOGGER.info("Startup CheckLicense for ${getProject().name}")
+        LicenseChecker licenseChecker = new LicenseChecker()
+        LOGGER.info("Check licenses if they are allowed to use.")
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            getAllowedLicenseFile(), getProjectDependenciesData(), notPassedDependenciesFile)
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -36,6 +36,7 @@ class LicenseReportExtension {
     public boolean excludeOwnGroup
     public String[] excludeGroups
     public String[] excludes
+    public File allowedLicensesFile
 
     LicenseReportExtension(Project project) {
         outputDir = "${project.buildDir}/reports/dependency-license"

--- a/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
@@ -29,7 +29,13 @@ class LicenseReportPlugin implements Plugin<Project> {
         assertCompatibleGradleVersion()
 
         project.extensions.create('licenseReport', LicenseReportExtension, project)
-        project.tasks.create('generateLicenseReport', ReportTask)
+        def preparationTask = project.tasks.create("checkLicensePreparation", CheckLicensePreparationTask)
+        def generateLicenseReportTask = project.tasks.create('generateLicenseReport', ReportTask) {
+            it.shouldRunAfter(preparationTask)
+        }
+        project.tasks.create('checkLicense', CheckLicenseTask) {
+            it.dependsOn(preparationTask, generateLicenseReportTask)
+        }
     }
 
     private void assertCompatibleGradleVersion() {

--- a/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.check
+
+import groovy.json.JsonOutput
+import org.gradle.api.GradleException
+
+class LicenseChecker {
+
+    void checkAllDependencyLicensesAreAllowed(
+        File allowedLicensesFile, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
+        List<Dependency> allDependencies = LicenseCheckerFileReader.importDependencies(projectLicensesDataFile)
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile)
+        List<Dependency> notPassedDependencies = searchForNotAllowedDependencies(allDependencies, allowedLicenses)
+        generateNotPassedDependenciesFile(notPassedDependencies, notPassedDependenciesOutputFile)
+
+        if (!notPassedDependencies.isEmpty()) {
+            throw new GradleException("Some library licenses are not allowed.\n" +
+                "Read [$notPassedDependenciesOutputFile.path] for more information.")
+        }
+    }
+
+    private List<Dependency> searchForNotAllowedDependencies(
+        List<Dependency> dependencies, List<AllowedLicense> allowedLicenses) {
+        return dependencies.findAll { !isDependencyHasAllowedLicense(it, allowedLicenses) }
+    }
+
+    private void generateNotPassedDependenciesFile(
+        List<Dependency> notPassedDependencies, File notPassedDependenciesOutputFile) {
+        notPassedDependenciesOutputFile.text =
+            JsonOutput.prettyPrint(JsonOutput.toJson(
+                ["dependenciesWithoutAllowedLicenses": notPassedDependencies.collect { toAllowedLicenseList(it) }.flatten()]))
+    }
+
+    private boolean isDependencyHasAllowedLicense(Dependency dependency, List<AllowedLicense> allowedLicenses) {
+        for(allowedLicense in allowedLicenses) {
+            if (isDependencyMatchesAllowedLicense(dependency, allowedLicense)) return true
+        }
+        return false
+    }
+
+    private boolean isDependencyMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        return isDependencyNameMatchesAllowedLicense(dependency, allowedLicense) &&
+            isDependencyLicenseMatchesAllowedLicense(dependency, allowedLicense) &&
+            isDependencyVersionMatchesAllowedLicense(dependency, allowedLicense)
+    }
+
+    private boolean isDependencyNameMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        return dependency.moduleName ==~ allowedLicense.moduleName || allowedLicense.moduleName == null ||
+            dependency.moduleName == allowedLicense.moduleName
+    }
+
+    private boolean isDependencyVersionMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        return dependency.moduleVersion ==~ allowedLicense.moduleVersion || allowedLicense.moduleVersion == null ||
+            dependency.moduleVersion == allowedLicense.moduleVersion
+    }
+
+    private boolean isDependencyLicenseMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        if (allowedLicense.moduleLicense == null || allowedLicense.moduleLicense == ".*") return true
+
+        for (moduleLicenses in dependency.moduleLicenses)
+            if (moduleLicenses.moduleLicense ==~ allowedLicense.moduleLicense ||
+                moduleLicenses.moduleLicense == allowedLicense.moduleLicense) return true
+        return false
+    }
+
+    private List<AllowedLicense> toAllowedLicenseList(Dependency dependency) {
+        if (dependency.moduleLicenses.isEmpty()) {
+            return [ new AllowedLicense(dependency.moduleName, dependency.moduleVersion, null) ]
+        } else {
+            return dependency.moduleLicenses.collect { new AllowedLicense(dependency.moduleName, dependency.moduleVersion, it.moduleLicense) }
+        }
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.check
+
+import groovy.json.JsonParserType
+import groovy.json.JsonSlurper
+
+class LicenseCheckerFileReader {
+
+    static List<AllowedLicense> importAllowedLicenses(File allowedLicensesFile) {
+        def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(allowedLicensesFile)
+        return slurpResult.allowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }
+    }
+
+    static List<Dependency> importDependencies(File projectDependenciesFile) {
+        def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(projectDependenciesFile)
+        def allDependencies = slurpResult.dependencies.collect { new Dependency(it.moduleName, it.moduleVersion, it.moduleLicenses) }
+        allDependencies += slurpResult.importedModules.collect { new Dependency(it.dependencies) }
+        return allDependencies
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/check/LicenseCheckerModel.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseCheckerModel.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.check
+
+import groovy.transform.EqualsAndHashCode
+
+@EqualsAndHashCode
+class AllowedLicense {
+    String  moduleName, moduleLicense, moduleVersion
+
+    AllowedLicense(String moduleName, String moduleVersion, String moduleLicense) {
+        this.moduleName = moduleName
+        this.moduleVersion = moduleVersion
+        this.moduleLicense = moduleLicense
+    }
+}
+
+class Dependency {
+    String moduleName, moduleVersion
+    List<ModuleLicense> moduleLicenses
+
+    Dependency(String moduleName, String moduleVersion, List moduleLicenses) {
+        this.moduleName = moduleName
+        this.moduleVersion = moduleVersion
+        this.moduleLicenses = moduleLicenses.collect { new ModuleLicense(it.moduleLicense) }
+    }
+
+    Dependency(Map dependencies) {
+        this.moduleName = dependencies.moduleName
+        this.moduleVersion = dependencies.moduleVersion
+        this.moduleLicenses = [ new ModuleLicense(dependencies.moduleLicense) ]
+    }
+}
+
+class ModuleLicense {
+    String moduleLicense
+
+    ModuleLicense(String moduleLicense) {
+        this.moduleLicense = moduleLicense
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/CheckLicenseTaskSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/CheckLicenseTaskSpec.groovy
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class CheckLicenseTaskSpec extends Specification{
+    @Rule
+    final TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File buildFile
+    File localBuildCacheDirectory
+    File allowed
+
+    BuildResult result(String[] arguments){
+        return GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(arguments)
+            .build()
+    }
+    BuildResult failResult(String[] arguments){
+        return GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments(arguments)
+            .buildAndFail()
+    }
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+        localBuildCacheDirectory = testProjectDir.newFolder('.local-cache')
+        testProjectDir.newFile('settings.gradle') << """
+        buildCache {
+            local {
+                directory '${localBuildCacheDirectory.toURI()}'
+            }
+        }
+    """
+        allowed = testProjectDir.newFile('allowed-licenses.json') << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*", 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, 
+                    Version 1.1", "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "Apache License, Version 2.0" 
+                },
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                },
+                { 
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains" 
+                }
+            ]
+        }"""
+    }
+
+    def "it should pass when only containing included licenses"() {
+        given:
+        buildFile << """
+            import com.github.jk1.license.filter.*
+      
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+            apply plugin: 'java'
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                filters = new LicenseBundleNormalizer()
+                allowedLicensesFile = new File("${allowed.path}")
+            }
+        """
+
+        when:
+        BuildResult buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.SUCCESS
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        buildResult = result( "--build-cache", "clean", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        buildResult = result( "--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "it should fail when some dependencies not allowed and pass when allowedLicensesFile add new allowedLicenses"() {
+        given:
+
+        allowed.text = """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                }
+            ]
+        }"""
+        buildFile << """
+            import com.github.jk1.license.filter.*
+            
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+            apply plugin: 'java'
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                filters = new LicenseBundleNormalizer()
+                allowedLicensesFile = new File("${allowed.path}")
+            }
+        """
+
+        when:
+        BuildResult buildResult = failResult( "--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FAILED
+
+        when:
+        allowed.text = """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*", 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "Apache License, Version 2.0" 
+                },
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "cOMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                },
+                { 
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains.*" 
+                }
+            ]
+        }"""
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.SUCCESS
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        buildResult = result( "--build-cache", "clean", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        buildResult = result( "--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "it should fail when not containing included checkFile and pass when renew allowedLicensesFile"() {
+        given:
+        buildFile << """
+
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+            apply plugin: 'java'
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                allowedLicensesFile = new File("./config/allowed-licenses.json")
+            }
+        """
+
+        allowed.text = """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*", 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "Apache License, Version 2.0" 
+                },
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "cOMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                },
+                { 
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains.*" 
+                }
+            ]
+        }"""
+
+        when:
+        BuildResult buildResult = failResult( "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FAILED
+
+        when:
+        buildFile.text = """
+            
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+            apply plugin: 'java'
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                allowedLicensesFile = new File("${allowed.path}")
+            }
+        """
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.SUCCESS
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        buildResult = result( "--build-cache", "clean", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        buildResult = result( "--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+    }
+    def "it should fail when no allowedLicensesFile specified and pass when adding allowedLicensesFile"() {
+        given:
+        buildFile << """
+            
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+            apply plugin: 'java'
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+        """
+
+        allowed.text = """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*", 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "Apache License, Version 2.0" 
+                },
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "cOMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                },
+                { 
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains.*" 
+                }
+            ]
+        }"""
+
+        when:
+        BuildResult buildResult = result( "checkLicense")
+
+        then:
+        thrown Exception
+
+        when:
+        buildFile.text = """
+            
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+            apply plugin: 'java'
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                allowedLicensesFile = new File("${allowed.path}")
+            }
+        """
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.SUCCESS
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        buildResult = result( "--build-cache", "clean", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        buildResult = result( "--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.check
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class LicenseCheckerFileReaderSpec extends Specification {
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File allowedLicenseFile
+    File projectDataFile
+
+    def setup() {
+        testProjectDir.create()
+        allowedLicenseFile = testProjectDir.newFile('test-allowed-licenses.json')
+        projectDataFile = testProjectDir.newFile('test-projectData.json')
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "License1" 
+                },
+                { 
+                    "moduleLicense": "License2" 
+                },
+                { 
+                    "moduleLicense": "License3" 
+                }
+            ]
+        }"""
+    }
+
+    def "it reads out all the allowed licenses"() {
+        when:
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+
+        then:
+        allowedLicenses.collect { it.moduleLicense } == ["License1", "License2", "License3"]
+        allowedLicenses.collect { it.moduleName } == [null,  null, null]
+    }
+
+    def "read null"() {
+
+        allowedLicenseFile.text = """{"allowedLicenses":[]}"""
+
+        when:
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+
+        then:
+        allowedLicenses == []
+    }
+
+    def "read allowedLicenses moduleName"() {
+
+        allowedLicenseFile.text = """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleName": "Name1" 
+                },
+                { 
+                    "moduleName": "Name2" 
+                },
+                { 
+                    "moduleName": "Name3" 
+                }
+            ]
+        }"""
+
+        when:
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+
+        then:
+        allowedLicenses.moduleLicense == [null, null, null]
+        allowedLicenses.moduleName == ["Name1", "Name2", "Name3"]
+    }
+
+    def "read projectData dependencies moduleName"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                { 
+                    "moduleName": "Name1" 
+                },
+                { 
+                    "moduleName": "Name2" 
+                },
+                { 
+                    "moduleName": "Name3" 
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2", "Name3"]
+        dependencies.moduleLicenses.moduleLicense == [[], [], []]
+    }
+
+    def "read projectData dependencies moduleLicenses and moduleName"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                {
+                    "moduleName": "Name1",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://=========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                },
+                {
+                    "moduleName": "Name2",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2"]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], ["License2"]]
+    }
+
+    def "read projectData dependencies moduleLicenses"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                {
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://=========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                },
+                {
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == [null, null]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], ["License2"]]
+    }
+
+    def "read projectData dependencies null"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == []
+        dependencies.moduleLicenses == []
+    }
+
+    def "read projectData importedModules"() {
+
+        projectDataFile.text = """
+        {
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name1",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License1",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name2",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License2",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2"]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], ["License2"]]
+    }
+
+    def "read projectData importedModules moduleName"() {
+
+        projectDataFile.text = """
+        {
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name1",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name2",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2"]
+        dependencies.moduleLicenses.moduleLicense == [[null], [null]]
+    }
+
+    def "read projectData importedModules moduleLicense"() {
+
+        projectDataFile.text = """
+        {
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License1",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License2",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == [null, null]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], ["License2"]]
+    }
+
+    def "read projectData importedModules and dependencies"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                {
+                    "moduleName": "Name1",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://=========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                },
+                {
+                    "moduleName": "Name2",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://========/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "http://======="
+                        }
+                    ]
+                }
+            ],
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name3",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License3",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name4",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicense": "License4",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2", "Name3", "Name4"]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], ["License2"], ["License3"], ["License4"]]
+    }
+
+    def "read projectData dependencies with multiple moduleLicense"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                {
+                    "moduleName": "Name1",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://=======/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "http://========="
+                        },
+                        {
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "http://====="
+                        },
+                        {
+                            "moduleLicense": "License3",
+                            "moduleLicenseUrl": "http://========"
+                        }
+                    ]
+                },
+                {
+                    "moduleName": "Name2",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://======/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "http://========"
+                        }
+                    ]
+                }
+            ],
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name3",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleLicense": "License3",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name4",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleLicense": "License4",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == ["Name1", "Name2", "Name3", "Name4"]
+        dependencies.moduleLicenses.moduleLicense == [["License1", "License2", "License3"], ["License2"], ["License3"], ["License4"]]
+    }
+
+    def "read projectData random null moduleName and module License of importedModules and dependencies"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies":[
+                {
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://kotlinlang.org/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                        }
+                    ]
+                },
+                {
+                    "moduleName": "Name2",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://kotlinlang.org/"
+                    ]
+                },
+                {
+                    "moduleName": "Name3",
+                    "moduleVersion": "1.2.60",
+                    "moduleUrls": [
+                        "https://kotlinlang.org/"
+                    ],
+                    "moduleLicenses": [
+                        {
+                            "moduleLicenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+                        }
+                    ]
+                }
+            ],
+            "importedModules": [
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleUrl": "some-projectUrl",
+                        "moduleLicense": "License3",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                },
+                {
+                    "moduleName": "bundle1",
+                    "dependencies": {
+                        "moduleName": "Name5",
+                        "moduleUrl": "some-projectUrl",
+                        "moduleVersion": "some-version",
+                        "moduleLicenseUrl": "apache-url"
+                    }
+                }
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies.moduleName == [null, "Name2", "Name3", null, "Name5"]
+        dependencies.moduleLicenses.moduleLicense == [["License1"], [], [null], ["License3"], [null]]
+    }
+
+    def "read projectData random null of importedModules and dependencies"() {
+
+        projectDataFile.text = """
+        {
+            "dependencies": [
+            ],
+            "importedModules": [
+            ]
+        }"""
+
+        when:
+        List<Dependency> dependencies = LicenseCheckerFileReader.importDependencies(projectDataFile)
+
+        then:
+        dependencies == []
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
@@ -1,0 +1,895 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.check
+
+import groovy.json.JsonParserType
+import groovy.json.JsonSlurper
+import org.gradle.api.GradleException
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class LicenseCheckerSpec extends Specification {
+    @Rule
+    TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File allowedLicenseFile
+    File projectDataFile
+    File notPassedDependenciesFile
+
+    List<AllowedLicense> importNotPassedDependencies(File file) {
+        def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(file)
+        return slurpResult.dependenciesWithoutAllowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }
+    }
+
+    def setup() {
+        testProjectDir.create()
+        allowedLicenseFile = testProjectDir.newFile('test-allowed-licenses.json')
+        projectDataFile = testProjectDir.newFile('test-projectData.json')
+        notPassedDependenciesFile = testProjectDir.newFile('test-not-passed-dependencies.json')
+    }
+
+    def "check if constructor working with json file."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains", 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, 
+                    Version 1.1", "moduleName": "org.jetbrains.*" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", 
+                    "moduleName": "org.jetbrains" 
+                },
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "Apache License, Version 2.0" 
+                },
+                { 
+                    "moduleLicense": "The 2-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "The 3-Clause BSD License" 
+                },
+                { 
+                    "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                },
+                { 
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains" 
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains only allowed licenses will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                }
+            ]
+        }"""
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache Software License, Version 1.1"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains not allowed licenses will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1" 
+                },
+                { 
+                    "moduleLicense": "MIT License" 
+                }
+            ]
+        }"""
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "some-other-license"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["some-other-license"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains only allowed moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleName": ".*mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "some-other-license"
+                        }
+                    ], "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains not allowed moduleName will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { "moduleName": "mod1" }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod2"]
+        notPassedDependencies.moduleLicense == ["Apache License, Version 2.0"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData only contains allowed moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleName": "dummy-group:.*" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod3"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod4"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                        "moduleName": "dummy-group:mod5"
+                },
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod6"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains different license but same moduleName will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache Software License, Version 1.1", "moduleName": "mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod2"]
+        notPassedDependencies.moduleLicense == ["MIT License"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains moduleVersion and allowedLicense has the same will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "1.0" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2",
+                    "moduleVersion": "1.0"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains moduleVersion and allowedLicense with different moduleVersion will fail."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "2.0" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2",
+                    "moduleVersion": "1.0"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod2"]
+        notPassedDependencies.moduleLicense == ["MIT License"]
+        notPassedDependencies.moduleVersion == ["1.0"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains moduleVersion and allowedLicense with no moduleVersion will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "MIT License", "moduleName": ".*mod2"
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "MIT License"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2",
+                    "moduleVersion": "1.0"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Check when ProjectData contains no license but same moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Check when allowedLicenses contains .* in moduleLicense and projectData contain same moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": ".*", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains same license but different moduleName will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod2"]
+        notPassedDependencies.moduleLicense == ["Apache License, Version 2.0"]
+        thrown GradleException
+    }
+    def "check when ProjectData contains same license and same moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", 
+                    "moduleName": ".*mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains same license and different moduleName will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", 
+                    "moduleName": "some-other-groups" 
+                }
+            ]
+        }"""
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["GNU LESSER GENERAL PUBLIC LICENSE, Version 3"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains different moduleName will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleName": "some-other-groups:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["GNU LESSER GENERAL PUBLIC LICENSE, Version 3"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains same moduleName will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains one different value(license) will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "some-other-license"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["some-other-license"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains one different value(moduleName) will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod2"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod2"]
+        notPassedDependencies.moduleLicense == ["Apache License, Version 2.0"]
+        thrown GradleException
+    }
+
+    def "check when there is nothing in allowedLicenses it will fail as expected."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["Apache License, Version 2.0"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains multiple licenses and match with one allowed license will pass."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {
+                            "moduleLicense": "License1"
+                        },
+                        {
+                            "moduleLicense": "License2"
+                        },
+                        {
+                            "moduleLicense": "Apache License, Version 2.0"
+                        }
+                    ], 
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "check when ProjectData contains multiple licenses and have match with no allowed license will fail."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                { 
+                    "moduleLicense": "Apache License, Version 2.0", 
+                    "moduleName": "dummy-group:mod1" 
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                { 
+                    "moduleLicenses": [
+                        {"moduleLicense": "License1"},
+                        {"moduleLicense": "License2"},
+                        {"moduleLicense": "License3"}
+                    ], 
+                "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1", "dummy-group:mod1", "dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["License1", "License2", "License3"]
+        thrown GradleException
+    }
+}


### PR DESCRIPTION
When having a project, not always all licenses are allowed to be used
like GPL in commercial programs. This commit allows to define a file
where allowed licenses can be specified and by running the new task
'checkLicense', all the dependencies are checked against that file.
If licenses are not allowed, the task fails.

See the README for more details and samples