### PR TITLE
Optimize read project times

### DIFF
--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -89,7 +89,7 @@ class LicenseFileData {
     @Deprecated
     Collection<String> files = []
 
-    Collection<LicenseFileDetails> fileDetails = []
+    Collection<LicenseFileDetails> fileDetails = new TreeSet<LicenseFileDetails>()
 }
 
 @Sortable

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -84,7 +84,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         data.configurations*.dependencies.flatten().forEach { normalizePoms(it) }
         data.configurations*.dependencies.flatten().forEach { normalizeManifest(it) }
-        data.configurations*.dependencies.flatten().forEach { normalizeLicenseFileDetailsLicense(it) }
+        data.configurations*.dependencies.flatten().forEach { normalizeLicenseFileDetails(it) }
         data.importedModules.forEach { normalizeImportedModuleBundle(it) }
 
         data = duplicateFilter.filter(data)
@@ -100,16 +100,18 @@ class LicenseBundleNormalizer implements DependencyFilter {
         }
     }
     private def normalizeManifest(ModuleData dependency) {
-        List<ManifestData> normalizedManifests = dependency.manifests.collect { normalizeManifestLicense(it) }.flatten()
+        List<ManifestData> normalizedManifests = dependency.manifests.collect {
+            normalizeManifestLicense(it)
+        }.flatten()
         dependency.manifests.clear()
         dependency.manifests.addAll(normalizedManifests)
     }
-    private def normalizeLicenseFileDetailsLicense(ModuleData dependency) {
-        dependency.licenseFiles.forEach { licenseFiles ->
+    private def normalizeLicenseFileDetails(ModuleData dependency) {
+        dependency.licenseFiles.forEach { licenseFile ->
             List<LicenseFileDetails> normalizedDetails =
-                licenseFiles.fileDetails.collect { normalizeLicenseFileDetailsLicense(it) }.flatten()
-            licenseFiles.fileDetails.clear()
-            licenseFiles.fileDetails.addAll(normalizedDetails)
+                licenseFile.fileDetails.collect { normalizeLicenseFileDetailsLicense(it) }.flatten()
+            licenseFile.fileDetails.clear()
+            licenseFile.fileDetails.addAll(normalizedDetails)
         }
     }
 

--- a/src/main/groovy/com/github/jk1/license/reader/CachedModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/CachedModuleReader.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.reader
+
+import com.github.jk1.license.ModuleData
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ResolvedDependency
+
+class CachedModuleReader {
+
+    private ModuleReader moduleReader = new ModuleReader()
+    private Map<String, ModuleData> moduleDataCache = [:]
+
+    ModuleData read(Project project, ResolvedDependency dependency) {
+        String dataName = "${dependency.moduleGroup}:${dependency.moduleName}:${dependency.moduleVersion}"
+        return moduleDataCache.computeIfAbsent(dataName) {
+            moduleReader.read(project, dependency)
+        }
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -26,16 +26,18 @@ import org.gradle.api.logging.Logging
 
 import static com.github.jk1.license.reader.ProjectReader.isResolvable
 
-
 class ConfigurationReader {
 
     private Logger LOGGER = Logging.getLogger(ReportTask.class)
-    private ModuleReader moduleReader = new ModuleReader()
+    private CachedModuleReader moduleReader
     private LicenseReportExtension config
+
+    ConfigurationReader(CachedModuleReader moduleReader) {
+        this.moduleReader = moduleReader
+    }
 
     ConfigurationData read(Project project, Configuration configuration) {
         config = project.licenseReport
-
         ConfigurationData data = new ConfigurationData()
         data.name = configuration.name
 
@@ -51,6 +53,7 @@ class ConfigurationReader {
         for (ResolvedDependency dependency : configuration.resolvedConfiguration.getFirstLevelModuleDependencies()) {
             collectDependencies(dependencies, dependency)
         }
+
         LOGGER.info("Processing dependencies for configuration [$configuration]: " + dependencies.join(','))
         for (ResolvedDependency dependency : dependencies) {
             LOGGER.debug("Processing dependency: $dependency")

--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -31,8 +31,8 @@ class ModuleReader {
     private ManifestReader manifestReader = new ManifestReader()
     private LicenseFilesReader filesReader = new LicenseFilesReader()
 
-    ModuleData read(Project project, ResolvedDependency dependency){
-        ModuleData data = new ModuleData(dependency.moduleGroup, dependency.moduleName, dependency.moduleVersion)
+    ModuleData read(Project project, ResolvedDependency dependency) {
+        ModuleData moduleData = new ModuleData(dependency.moduleGroup, dependency.moduleName, dependency.moduleVersion)
         dependency.moduleArtifacts.each { ResolvedArtifact artifact ->
             LOGGER.info("Processing artifact: $artifact ($artifact.file)")
             if (artifact.file.exists()){
@@ -40,13 +40,13 @@ class ModuleReader {
                 def manifest = manifestReader.readManifestData(project, artifact)
                 def licenseFile = filesReader.read(project, artifact)
 
-                if (pom) data.poms << pom
-                if (manifest) data.manifests << manifest
-                if (licenseFile) data.licenseFiles << licenseFile
+                if (pom) moduleData.poms << pom
+                if (manifest) moduleData.manifests << manifest
+                if (licenseFile) moduleData.licenseFiles << licenseFile
             } else {
                 LOGGER.info("Skipping artifact file $artifact.file as it does not exist")
             }
         }
-        data
+        return moduleData
     }
 }

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -26,7 +26,8 @@ import org.gradle.api.logging.Logging
 class ProjectReader {
 
     private Logger LOGGER = Logging.getLogger(ReportTask.class)
-    private ConfigurationReader configurationReader = new ConfigurationReader()
+    private CachedModuleReader moduleReader = new CachedModuleReader()
+    private ConfigurationReader configurationReader = new ConfigurationReader(moduleReader)
 
     ProjectData read(Project project) {
         ProjectData data = new ProjectData()

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -277,14 +277,14 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
     {
         "fileDetails": [
             {
-                "licenseUrl": null,
-                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                "license": null
-            },
-            {
                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
+            },
+            {
+                "licenseUrl": null,
+                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                "license": null
             }
         ],
         "files": [

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -125,14 +125,14 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                                "license": null
-                            },
-                            {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
                             }
                         ],
                         "files": [
@@ -252,14 +252,14 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                                "license": null
-                            },
-                            {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
                             }
                         ],
                         "files": [
@@ -314,14 +314,14 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                                "license": null
-                            },
-                            {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
                             }
                         ],
                         "files": [
@@ -426,14 +426,14 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                                "license": null
-                            },
-                            {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
                             }
                         ],
                         "files": [

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -81,14 +81,14 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
     {
         "fileDetails": [
             {
-                "licenseUrl": null,
-                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                "license": null
-            },
-            {
                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
+            },
+            {
+                "licenseUrl": null,
+                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                "license": null
             }
         ],
         "files": [
@@ -409,14 +409,14 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                     {
                         "fileDetails": [
                             {
-                                "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                                "license": null
-                            },
-                            {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
                                 "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
+                            },
+                            {
+                                "licenseUrl": null,
+                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "license": null
                             }
                         ],
                         "files": [
@@ -564,12 +564,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],
@@ -621,12 +621,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],
@@ -678,12 +678,12 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],


### PR DESCRIPTION
The reader now will read the same dependency multiple times in one project.
Therefore, adding moduleDataCache to speed up the project reader.