### PR TITLE
Only consider configurations which are configured

### DIFF
--- a/src/main/groovy/com/github/jk1/license/ReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/ReportTask.groovy
@@ -35,7 +35,7 @@ class ReportTask extends DefaultTask {
     @InputFiles
     FileCollection getClasspath() {
         (getProject().subprojects + getProject())
-            .collectMany { ProjectReader.findConfigured(it) }
+            .collectMany { ProjectReader.findConfiguredConfigurations(it) }
             .inject(project.files(), { FileCollection memo, eachConfiguration -> memo + eachConfiguration })
     }
 


### PR DESCRIPTION
When a configuration is configured on a multi-platform project, only
those configurations should be considered an all the subprojects. If
a subproject doesn't have such a config, nothing shoudl be reported
from this module.

Currently, when a configuration is not found on a sub-project, the fallback is
to use just all the configurations of that sub-project. That can lead to 
unexpected reported licenses, e.g. if only `runtimeClasspath` licenses should 
be reported (an no test licenses) and a sub-project doesn't have a 
`runtimeClasspath` config, all of a sudden also test dependencies 
for this sub-project are reported.