### PR TITLE
Make the regex matching more restrictive

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -172,11 +172,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
     private List<NormalizerTransformationRule> findMatchingRulesForName(String name) {
         return normalizerConfig.transformationRules
-            .findAll { it.licenseNamePattern && (name == it.licenseNamePattern || name =~ it.licenseNamePattern) }
+            .findAll { it.licenseNamePattern && (name == it.licenseNamePattern || name ==~ it.licenseNamePattern) }
     }
     private List<NormalizerTransformationRule> findMatchingRulesForUrl(String url) {
         return normalizerConfig.transformationRules
-            .findAll { it.licenseUrlPattern && url =~ it.licenseUrlPattern }
+            .findAll { it.licenseUrlPattern && url ==~ it.licenseUrlPattern }
     }
     private List<NormalizerTransformationRule> findMatchingRulesForContentPattern(String content) {
         return normalizerConfig.transformationRules


### PR DESCRIPTION
The pattern currently was only checked with the find-operator. This is
not restrictive enough, because it sometimes finds matches where acutally
no matches are wanted. Now the comparision is done with the match-operator
for the license name and url so the user has full regex control