### PR TITLE
adding a renderer for download license files from internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,49 @@ licenseReport {
 }
 ```
 
+### DownloadLicensesRenderer
+
+The DownloadLicensesRenderer will download all the license files which include url. You can specified licenseUrl to 
+certain license file. When no value pass to DownloadLicenseRenderer the default value is empty Map.
+
+```groovy
+import com.github.jk1.license.render.*
+Map<String, File> customizeLicenseFile = [
+   "http://www.opensource.org/licenses/mit-license.php" : new File("./gradle/default_license/MIT.txt")
+]
+
+licenseReport {
+    renderers = [new DownloadLicensesRenderer(customizeLicenseFile)]
+}
+```
+
+After download all the license files, it will generate a report for all license files report as below. 
+And also a html file containing all html file content inside, which could specified customizeLicenseFile much easier.
+
+```json
+{
+  "noLicenseFileDependencies": [
+    "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.6.2"
+  ],
+  "noLicenseFileImportedModules": [
+        
+  ],
+  "downloadedHtmlLicenseFileDirectories": [
+    "org.projectlombok_lombok_1.16.20/DOWNLOADED-POM-LICENSES/MIT_License.html"
+  ],
+  "downloadedTextLicenseFileDirectories": [
+    "com.couchbase.client_core-io_1.6.1/DOWNLOADED-POM-LICENSES/Apache_License_Version_2_0.txt"
+  ],
+  "embeddedLicenseFileDirectories": [
+    "com.couchbase.client_core-io_1.5.7/META-INF/LICENSE"
+  ]
+}
+```
+```html
+<html><body><div><a href = "http://www.apache.org/licenses/">http://www.apache.org/licenses/</a></div></body></html>
+<html><body><div><a href = "http://www.gnu.org/software/classpath/license.html">http://www.gnu.org/software/classpath/license.html</a></div></body></html>
+<html><body><div><a href = "https://github.com/javaee/javax.annotation/blob/master/LICENSE">https://github.com/javaee/javax.annotation/blob/master/LICENSE</a></div></body></html>
+```
 
 ## Importers
 Importer adds license information from an external source to your report. Importer may come in handy if

--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -20,6 +20,7 @@ import com.github.jk1.license.LicenseFileDetails
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ReportTask
 import com.github.jk1.license.util.Files
+import com.github.jk1.license.util.Paths
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.logging.Logger
@@ -79,7 +80,8 @@ class LicenseFilesReader {
         return entryNames.collect { ZipEntry entry ->
             String entryName = entry.name
             if (!entryName.startsWith("/")) entryName = "/$entryName"
-            String path = "${artifact.file.name}${entryName}"
+            String fileName = Paths.createPathNameFrom(artifact)
+            String path = "${fileName}${entryName}"
             File file = new File(config.outputDir, path)
             file.parentFile.mkdirs()
             file.text = zipFile.getInputStream(entry).text

--- a/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
@@ -19,6 +19,7 @@ import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ReportTask
 import com.github.jk1.license.util.Files
+import com.github.jk1.license.util.Paths
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.logging.Logger
@@ -56,11 +57,13 @@ class ManifestReader {
                 if (mf) {
                     ManifestData data = manifestToData(mf)
                     def path = findLicenseFile(artifact.file, data.license)
-                    if (path != null){
+                    if (path != null) {
                         data.hasPackagedLicense = true
-                        File dest = new File(config.outputDir, "${artifact.file.name}/${data.license}.html")
-                        data.url="${artifact.file.name}/${data.license}.html"
+                        String fileName = Paths.createPathNameFrom(artifact)
+                        String destPath = "${config.outputDir}/${fileName}/EMBEDDED-MANIFEST-LICENSES"
+                        File dest = new File(destPath, data.license)
                         writeLicenseFile(artifact.file, path, dest)
+                        data.url = "${fileName}/EMBEDDED-MANIFEST-LICENSES/${data.license}"
                     }
                     return data
                 }
@@ -113,12 +116,12 @@ class ManifestReader {
         }
     }
 
-    private void writeLicenseFile(File artifactFile, String licenseFileName, File destinationFile) {
+    private void writeLicenseFile(File artifactFile, String licenseFileName, File dest) {
         try {
             ZipFile file = new ZipFile(artifactFile, ZipFile.OPEN_READ)
             ZipEntry entry = file.getEntry(licenseFileName)
-            destinationFile.parentFile.mkdirs()
-            destinationFile.text = file.getInputStream(entry).text
+            dest.parentFile.mkdirs()
+            dest.text = file.getInputStream(entry).text
         } catch (Exception e) {
             LOGGER.warn("Failed to write license file $licenseFileName from $artifactFile", e)
         }

--- a/src/main/groovy/com/github/jk1/license/render/DownloadLicensesRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/DownloadLicensesRenderer.groovy
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.render
+
+import com.github.jk1.license.ImportedModuleBundle
+import com.github.jk1.license.ImportedModuleData
+import com.github.jk1.license.LicenseFileDetails
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ManifestData
+import com.github.jk1.license.ModuleData
+import com.github.jk1.license.PomData
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.util.Paths
+import groovy.json.JsonOutput
+
+class DownloadLicensesRenderer implements ReportRenderer {
+    private Map<String, LicenseFileData> licenseUrlsToFileTextCache = [:]
+    private List<File> allLicenseFiles = []
+    private List<File> downloadedHtmlLicenseFiles = []
+    private List<File> downLoadedTextLicenseFiles = []
+    private List<File> embeddedLicenseFiles = []
+    private String htmlFileType = ".html"
+    private String textFileType = ".txt"
+
+    DownloadLicensesRenderer(Map<String, File> customizeLicenseUrlToLicenseFile = [:]) {
+        customizeLicenseUrlToLicenseFile.each {
+            licenseUrlsToFileTextCache.put(it.key, new LicenseFileData(textFileType, it.value.text))
+        }
+    }
+
+    void render(ProjectData projectData) {
+        LicenseReportExtension config= projectData.project.licenseReport
+        String outputDir = config.outputDir
+        downloadStoreAndReportDependenciesLicenses(projectData, outputDir)
+        downloadStoreAndReportImportedModulesLicenses(projectData, outputDir)
+        generateLicenseFileReport(projectData, outputDir)
+        generateAllHtmlUrlFile(outputDir)
+    }
+
+    private void downloadStoreAndReportDependenciesLicenses(ProjectData projectData, String outputDir) {
+        projectData.allDependencies.each { downloadStoreAndReportPomsLicenses(it, outputDir) }
+        projectData.allDependencies.each { downloadStoreAndReportManifestsLicenses(it, outputDir) }
+        projectData.allDependencies.each { reportEmbeddedManifestsLicenses(it, outputDir) }
+        projectData.allDependencies.each { reportEmbeddedLicenseFiles(it, outputDir) }
+    }
+
+    private void downloadStoreAndReportImportedModulesLicenses(ProjectData projectData, String outputDir) {
+        projectData.importedModules.each { downloadStoreAndReportImportedModuleLicenses(it, outputDir) }
+    }
+
+    private void generateLicenseFileReport(ProjectData projectData, String outputDir) {
+        File file = new File("${outputDir}/automatic-included-license-files-report.json")
+        file.createNewFile()
+        finalizeReportData()
+        file.text = JsonOutput.prettyPrint(JsonOutput.toJson([
+            "noLicenseFileDependencies": findAllNoLicenseFilesDependencies(projectData),
+            "noLicenseFileImportedModules": findAllNoLicenseFilesImportedModules(projectData),
+            "downloadedHtmlLicenseFileDirectories": Paths.allRelativePathBetween(downloadedHtmlLicenseFiles.path, outputDir),
+            "downloadedTextLicenseFileDirectories": Paths.allRelativePathBetween(downLoadedTextLicenseFiles.path, outputDir),
+            "embeddedLicenseFileDirectories": Paths.allRelativePathBetween(embeddedLicenseFiles.path, outputDir)
+        ]))
+    }
+
+    private void generateAllHtmlUrlFile(String outputDir) {
+        File file = new File("${outputDir}/automatic-included-license-html-files-contents.html")
+        file.createNewFile()
+        file.text = downloadedHtmlLicenseFiles.text.sort().join()
+    }
+
+    private void downloadStoreAndReportPomsLicenses(ModuleData dependency, String outputDir) {
+        String filePath = Paths.createPathNameFrom(dependency, "DOWNLOADED-POM-LICENSES")
+        dependency.poms.each { downloadStoreAndReportPomLicenses(it, outputDir, filePath) }
+    }
+
+    private void downloadStoreAndReportManifestsLicenses(ModuleData dependency, String outputDir) {
+        String filePath = Paths.createPathNameFrom(dependency, "DOWNLOADED-MANIFEST-LICENSES")
+        dependency.manifests.findAll { it.license }.each { downloadStoreAndReportManifestLicenses(it, outputDir, filePath) }
+    }
+
+    private void reportEmbeddedManifestsLicenses(ModuleData dependency, String outputDir) {
+        dependency.manifests.findAll { it.hasPackagedLicense }.each { reportEmbeddedLicenses(it.url, outputDir) }
+    }
+
+    private void reportEmbeddedLicenseFiles(ModuleData dependency, String outputDir) {
+        dependency.licenseFiles.each { reportEmbeddedFileDetailsLicenses(it.fileDetails, outputDir) }
+    }
+
+    private void downloadStoreAndReportImportedModuleLicenses(ImportedModuleBundle importedModule, String outputDir) {
+        importedModule.modules.findAll {it.licenseUrl}.each {
+            String filePath = Paths.createPathNameFrom(it, "DOWNLOADED-MODULE_LICENSES")
+            downloadStoreAndReportLicenses(it.licenseUrl, it.license, outputDir, filePath)
+        }
+    }
+
+    private void finalizeReportData() {
+        downloadedHtmlLicenseFiles = allLicenseFiles.findAll { it.name.contains(htmlFileType) }
+        downLoadedTextLicenseFiles = allLicenseFiles.findAll { it.path.contains("DOWNLOADED") && it.name.contains(textFileType)}
+        embeddedLicenseFiles = allLicenseFiles.findAll { !it.path.contains("DOWNLOADED") }
+    }
+
+    private List<String> findAllNoLicenseFilesDependencies(ProjectData projectData) {
+        projectData.allDependencies.findAll { isDependencyHasNoLicenseFile(it) }
+            .collect { "${it.group}:${it.name}:${it.version}".toString() }.sort()
+    }
+
+    private List<String> findAllNoLicenseFilesImportedModules(ProjectData projectData) {
+        projectData.importedModules.modules.flatten().findAll { isImportedModuleHasNoLicenseFile(it) }
+            .collect { "${it.name}:${it.version}".toString() }.sort()
+    }
+
+    private void downloadStoreAndReportPomLicenses(PomData pom, String outputDir, String filePath) {
+        pom.licenses.findAll { it.url }.each { downloadStoreAndReportLicenses(it.url, it.name, outputDir, filePath) }
+    }
+
+    private void downloadStoreAndReportManifestLicenses(ManifestData manifest, String outputDir, String filePath) {
+        List<String> licenseUrls = manifest.license.split(/([,])/)*.trim().findAll { !it.contains(" ") }
+        licenseUrls.each { downloadStoreAndReportLicenses(it, it, outputDir, filePath) }
+    }
+
+    private void reportEmbeddedFileDetailsLicenses(Collection<LicenseFileDetails> fileDetails, String outputDir) {
+        fileDetails.collect { it.file }.findAll { it }.each { reportEmbeddedLicenses(it, outputDir) }
+    }
+
+    private boolean isDependencyHasNoLicenseFile(ModuleData dependency) {
+        allLicenseFiles.path.findAll { it.contains(Paths.createPathNameFrom(dependency)) }.empty
+    }
+
+    private boolean isImportedModuleHasNoLicenseFile(ImportedModuleData importedModuleData) {
+        allLicenseFiles.path.findAll { it.contains(Paths.createPathNameFrom(importedModuleData)) }.empty
+    }
+
+    private void downloadStoreAndReportLicenses(String licenseUrl, String licenseName, String outputDir, String filePath) {
+        LicenseFileData fileData = downloadFileTextIfNotInCache(licenseUrl)
+        File newFile = createLicenseFile("${outputDir}/${filePath}", licenseName, fileData.fileType, fileData.fileText)
+        allLicenseFiles.push(newFile)
+    }
+
+    private void reportEmbeddedLicenses(String url, String outputDir) {
+        File localFile = new File("${outputDir}/${url}")
+        allLicenseFiles.push(localFile)
+    }
+
+    private LicenseFileData downloadFileTextIfNotInCache(String url) {
+        return licenseUrlsToFileTextCache.computeIfAbsent(url) { downloadLicenseFileData(url) }
+    }
+
+    private File createLicenseFile(String filePath, String licenseName, String fileType, String fileText) {
+        String fileName = Paths.createFileNameFromLicenseName(licenseName, fileType)
+        File file = new File(filePath, fileName)
+        if (file.exists() && file.text != fileText) file = new File(filePath, fileName.replace(fileType, "_1${fileType}"))
+        file.parentFile.mkdirs()
+        file.createNewFile()
+        file.text = fileText
+        return file
+    }
+
+    private LicenseFileData downloadLicenseFileData(String url) {
+        try {
+            URLConnection urlConnection = new URL(url).openConnection()
+            urlConnection.addRequestProperty("Accept", "text/plain")
+            if (urlConnection.contentType) {
+                if (urlConnection.contentType.contains("text/plain")) {
+                    return new LicenseFileData(textFileType, urlConnection.inputStream.text)
+                }
+            }
+            return new LicenseFileData(htmlFileType, urlToHtmlText(url))
+        } catch (IOException e) {
+            return new LicenseFileData(htmlFileType, urlToHtmlText(url))
+        }
+    }
+
+    private String urlToHtmlText(String url) {
+        return "<html><body><div><a href = \"${url}\">${url}</a></div></body></html>\n"
+    }
+
+    /**this could replace the github url to raw files*/
+    /*private String replaceGitHubLicenseUrl(String licenseUrl) {
+        if (licenseUrl.contains("https://github.com/") && licenseUrl.contains("blob/")) {
+            licenseUrl = licenseUrl.replace("https://github.com", "https://raw.githubusercontent.com")
+            .replace("blob/", "")
+        }
+        return licenseUrl
+    }*/
+
+    /**this could replace the gnu url to txt files*/
+    /*private String replaceGnuLicenseUrl(String licenseUrl) {
+        if (licenseUrl.contains("www.gnu.org") && !licenseUrl.contains("classpath")) {
+            licenseUrl = licenseUrl.replace(".html", ".txt")
+        }
+        return licenseUrl
+    }*/
+
+
+    /**this could add default License Text to certain url*/
+    /*private void addDefaultLicenseText(Map<String, String> customizeLicenseText) {
+        customizeLicenseText.each {
+            licenseUrlsToFileTextCache.put(it.key, it.value)
+        }
+    }*/
+
+    private static class LicenseFileData {
+        String fileType, fileText
+
+        LicenseFileData(String fileType, String fileText) {
+            this.fileType = fileType
+            this.fileText = fileText
+        }
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -18,6 +18,7 @@ package com.github.jk1.license.render
 import com.github.jk1.license.License
 import com.github.jk1.license.LicenseFileDetails
 import com.github.jk1.license.ModuleData
+import com.github.jk1.license.util.Urls
 
 class LicenseDataCollector {
 
@@ -48,7 +49,7 @@ class LicenseDataCollector {
                 info.moduleUrls << manifest.url
             }
             if (manifest.license) {
-                if (isValidUrl(manifest.license)) {
+                if (Urls.isValidUrl(manifest.license)) {
                     if (!info.licenses.find { it.url == manifest.license })
                         info.licenses << new License(url: manifest.license)
                 } else {
@@ -66,15 +67,6 @@ class LicenseDataCollector {
             }
         }
         info
-    }
-
-    private static boolean isValidUrl(String url) {
-        try {
-            new URI(url)
-            return true
-        } catch (URISyntaxException e) {
-            return false
-        }
     }
 
     private static def lastOrNull(Collection l) {

--- a/src/main/groovy/com/github/jk1/license/util/Paths.groovy
+++ b/src/main/groovy/com/github/jk1/license/util/Paths.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.util
+
+import com.github.jk1.license.ImportedModuleData
+import com.github.jk1.license.ModuleData
+import org.gradle.api.artifacts.ResolvedArtifact
+
+class Paths {
+    static String createPathNameFrom(ResolvedArtifact artifact) {
+        return artifact.id.componentIdentifier.displayName.replace(":", "_")
+    }
+
+    static String createPathNameFrom(ModuleData dependency, String customizeDirectory = "") {
+        return "${dependency.group}_${dependency.name}_${dependency.version}/${customizeDirectory}"
+    }
+
+    static String createPathNameFrom(ImportedModuleData moduleData, String customizeDirectory = "") {
+        return "${moduleData.name}_${moduleData.version}/${customizeDirectory}"
+    }
+
+    static String createFileNameFromLicenseName(String licenseName, String fileType) {
+        if (licenseName == null) return "LICENSE${fileType}"
+        else if (licenseName.isAllWhitespace() || licenseName.isEmpty()) return "LICENSE${fileType}"
+        return licenseName.split("/").last().split(/([ .,-])/).findAll { it != "" }.join("_") + fileType
+    }
+
+    static List<String> allRelativePathBetween(Collection<String> originalPaths, String parentPath) {
+        return originalPaths.collect { relativePathBetween(it, parentPath) }.sort()
+    }
+
+    static String relativePathBetween(String originalPath, String parentPath) {
+        return originalPath.replace(parentPath + "/", "")
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/util/Urls.groovy
+++ b/src/main/groovy/com/github/jk1/license/util/Urls.groovy
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.jk1.license.render
+package com.github.jk1.license.util
 
-import com.github.jk1.license.ProjectData
-
-interface ReportRenderer {
-    void render(ProjectData data)
+class Urls {
+    static boolean isValidUrl(String url) {
+        try {
+            new URI(url)
+            return true
+        } catch (URISyntaxException e) {
+            return false
+        }
+    }
 }

--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -16,7 +16,7 @@
 {
   "bundles" : [
     { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-1.1" },
-    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "https://www.apache.org/licenses/LICENSE-2.0.txt" },
     { "bundleName" : "bsd-2",   "licenseName" : "The 2-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-2-Clause" },
     { "bundleName" : "bsd-3",   "licenseName" : "The 3-Clause BSD License", "licenseUrl" : "https://opensource.org/licenses/BSD-3-Clause" },
     { "bundleName" : "cc0",     "licenseName" : "Creative Commons Legal Code", "licenseUrl" : "https://repository.jboss.org/licenses/cc0-1.0.txt" },
@@ -25,11 +25,11 @@
     { "bundleName" : "cpl-1.0", "licenseName" : "Common Public License - v 1.0", "licenseUrl" : "https://www.eclipse.org/legal/cpl-v10.html" },
     { "bundleName" : "epl1",    "licenseName" : "Eclipse Public License - v 1.0", "licenseUrl" : "http://www.eclipse.org/legal/epl-v10.html" },
     { "bundleName" : "epl2",    "licenseName" : "Eclipse Public License - v 2.0", "licenseUrl" : "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt" },
-    { "bundleName" : "gpl1",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 1", "licenseUrl" : "https://www.gnu.org/licenses/gpl-1.0" },
-    { "bundleName" : "gpl2",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 2", "licenseUrl" : "https://www.gnu.org/licenses/gpl-2.0" },
-    { "bundleName" : "gpl3",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/gpl-3.0" },
-    { "bundleName" : "lgpl2.1", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1" },
-    { "bundleName" : "lgpl3",   "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0" },
+    { "bundleName" : "gpl1",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 1", "licenseUrl" : "https://www.gnu.org/licenses/gpl-1.0.txt" },
+    { "bundleName" : "gpl2",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 2", "licenseUrl" : "https://www.gnu.org/licenses/gpl-2.0.txt" },
+    { "bundleName" : "gpl3",    "licenseName" : "GNU GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/gpl-3.0.txt" },
+    { "bundleName" : "lgpl2.1", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1.txt" },
+    { "bundleName" : "lgpl3",   "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0.txt" },
     { "bundleName" : "mit",     "licenseName" : "MIT License", "licenseUrl" : "https://opensource.org/licenses/MIT" },
     { "bundleName" : "mpl1.1",  "licenseName" : "Mozilla Public License Version 1.1", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/1.1" },
     { "bundleName" : "mpl2",    "licenseName" : "Mozilla Public License, Version 2.0", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/2.0" }
@@ -43,6 +43,13 @@
     { "bundleName" : "mit",     "licenseUrlPattern" : ".*www.opensource.org/licenses/mit-license.php" },
     { "bundleName" : "apache2", "licenseFileContentPattern" : ".*Apache License, Version 2.0.*" },
     { "bundleName" : "apache1", "licenseFileContentPattern" : ".*Apache Software License, Version 1.1.*" },
-    { "bundleName" : "cddl1",   "licenseFileContentPattern" : ".*CDDL.*1.0" }
+    { "bundleName" : "cddl1",   "licenseFileContentPattern" : ".*CDDL.*1.0" },
+    { "bundleName" : "apache2", "licenseUrlPattern" : "https://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "gpl1",    "licenseUrlPattern" : "https://www.gnu.org/licenses/gpl-1.0" },
+    { "bundleName" : "gpl2",    "licenseUrlPattern" : "https://www.gnu.org/licenses/gpl-2.0" },
+    { "bundleName" : "gpl3",    "licenseUrlPattern" : "https://www.gnu.org/licenses/gpl-3.0" },
+    { "bundleName" : "lgpl2.1", "licenseUrlPattern" : "https://www.gnu.org/licenses/lgpl-2.1" },
+    { "bundleName" : "lgpl3",   "licenseUrlPattern" : "https://www.gnu.org/licenses/lgpl-3.0" },
+    { "bundleName" : "mit",     "licenseUrlPattern" : "https://opensource.org/licenses/MIT" }
   ]
 }

--- a/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
+++ b/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
@@ -80,8 +80,8 @@ class PluginCompatibilityTest extends Specification {
             "moduleName": "org.ehcache:ehcache",
             "moduleVersion": "3.3.1",
             "moduleUrls": [
-                "ehcache-3.3.1.jar/LICENSE.html",
-                "http://ehcache.org"
+                "http://ehcache.org",
+                "org.ehcache_ehcache_3.3.1/EMBEDDED-MANIFEST-LICENSES/LICENSE"
             ],
             "moduleLicenses": [
                 {
@@ -90,7 +90,7 @@ class PluginCompatibilityTest extends Specification {
                 },
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
             ]
         },

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -198,7 +198,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
             ]
         },
@@ -211,7 +211,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
             ]
         },
@@ -224,7 +224,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             "moduleLicenses": [
                 {
                     "moduleLicense": "Apache License, Version 2.0",
-                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
             ]
         }
@@ -260,36 +260,36 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
         "fileDetails": [
             {
                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                "file": "joda-time-2.9.9.jar/META-INF/LICENSE.txt",
+                "file": "joda-time_joda-time_2.9.9/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
             },
             {
                 "licenseUrl": null,
-                "file": "joda-time-2.9.9.jar/META-INF/NOTICE.txt",
+                "file": "joda-time_joda-time_2.9.9/META-INF/NOTICE.txt",
                 "license": null
             }
         ],
         "files": [
-            "joda-time-2.9.9.jar/META-INF/LICENSE.txt",
-            "joda-time-2.9.9.jar/META-INF/NOTICE.txt"
+            "joda-time_joda-time_2.9.9/META-INF/LICENSE.txt",
+            "joda-time_joda-time_2.9.9/META-INF/NOTICE.txt"
         ]
     },
     {
         "fileDetails": [
             {
                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
             },
             {
                 "licenseUrl": null,
-                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                 "license": null
             }
         ],
         "files": [
-            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
         ]
     }
 ]"""
@@ -423,17 +423,17 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
         "fileDetails": [
             {
                 "licenseUrl": "https://opensource.org/licenses/CDDL-1.0",
-                "file": "javax.annotation-api-1.3.2.jar/META-INF/LICENSE.txt",
+                "file": "javax.annotation_javax.annotation-api_1.3.2/META-INF/LICENSE.txt",
                 "license": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0"
             },
             {
                 "licenseUrl": "https://www.gnu.org/licenses/gpl-2.0",
-                "file": "javax.annotation-api-1.3.2.jar/META-INF/LICENSE.txt",
+                "file": "javax.annotation_javax.annotation-api_1.3.2/META-INF/LICENSE.txt",
                 "license": "GNU GENERAL PUBLIC LICENSE, Version 2"
             }
         ],
         "files": [
-            "javax.annotation-api-1.3.2.jar/META-INF/LICENSE.txt"
+            "javax.annotation_javax.annotation-api_1.3.2/META-INF/LICENSE.txt"
         ]
     }
 ]"""

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -127,18 +127,18 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+                            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
                         ]
                     }
                 ],
@@ -254,18 +254,18 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+                            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
                         ]
                     }
                 ],
@@ -316,18 +316,18 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+                            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
                         ]
                     }
                 ],
@@ -429,18 +429,18 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+                            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
                         ]
                     }
                 ],

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -57,8 +57,8 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
         then:
         runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
 
-        new File(outputDir, "commons-lang3-3.7.jar/META-INF/NOTICE.txt").exists()
-        new File(outputDir, "commons-lang3-3.7.jar/META-INF/LICENSE.txt").exists()
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt").exists()
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt").exists()
     }
 
     def "the project-data contains the license-file information"() {
@@ -82,18 +82,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
         "fileDetails": [
             {
                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                 "license": "Apache License, Version 2.0"
             },
             {
                 "licenseUrl": null,
-                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                 "license": null
             }
         ],
         "files": [
-            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
         ]
     }
 ]"""
@@ -353,18 +353,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-logging-1.1.1.jar/META-INF/LICENSE",
+                                "file": "commons-logging_commons-logging_1.1.1/META-INF/LICENSE",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-logging-1.1.1.jar/META-INF/NOTICE",
+                                "file": "commons-logging_commons-logging_1.1.1/META-INF/NOTICE",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-logging-1.1.1.jar/META-INF/LICENSE",
-                            "commons-logging-1.1.1.jar/META-INF/NOTICE"
+                            "commons-logging_commons-logging_1.1.1/META-INF/LICENSE",
+                            "commons-logging_commons-logging_1.1.1/META-INF/NOTICE"
                         ]
                     }
                 ],
@@ -410,18 +410,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "commons-lang3-3.7.jar/META-INF/LICENSE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
+                                "file": "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "commons-lang3-3.7.jar/META-INF/NOTICE.txt",
-                            "commons-lang3-3.7.jar/META-INF/LICENSE.txt"
+                            "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt",
+                            "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt"
                         ]
                     }
                 ],
@@ -437,7 +437,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "version": "3.3.1",
                         "license": "LICENSE",
                         "description": "Ehcache is an open-source caching library, compliant with the JSR-107 standard.",
-                        "url": "ehcache-3.3.1.jar/LICENSE.html",
+                        "url": "org.ehcache_ehcache_3.3.1/EMBEDDED-MANIFEST-LICENSES/LICENSE",
                         "name": "ehcache 3"
                     }
                 ],
@@ -467,18 +467,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "ehcache-3.3.1.jar/LICENSE",
+                                "file": "org.ehcache_ehcache_3.3.1/LICENSE",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": null,
-                                "file": "ehcache-3.3.1.jar/NOTICE",
+                                "file": "org.ehcache_ehcache_3.3.1/NOTICE",
                                 "license": null
                             }
                         ],
                         "files": [
-                            "ehcache-3.3.1.jar/LICENSE",
-                            "ehcache-3.3.1.jar/NOTICE"
+                            "org.ehcache_ehcache_3.3.1/LICENSE",
+                            "org.ehcache_ehcache_3.3.1/NOTICE"
                         ]
                     }
                 ],
@@ -564,18 +564,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "org.springframework_spring-beans_3.2.3.RELEASE/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "org.springframework_spring-beans_3.2.3.RELEASE/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],
                         "files": [
-                            "spring-beans-3.2.3.RELEASE.jar/META-INF/notice.txt",
-                            "spring-beans-3.2.3.RELEASE.jar/META-INF/license.txt"
+                            "org.springframework_spring-beans_3.2.3.RELEASE/META-INF/notice.txt",
+                            "org.springframework_spring-beans_3.2.3.RELEASE/META-INF/license.txt"
                         ]
                     }
                 ],
@@ -621,18 +621,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "org.springframework_spring-core_3.2.3.RELEASE/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "org.springframework_spring-core_3.2.3.RELEASE/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],
                         "files": [
-                            "spring-core-3.2.3.RELEASE.jar/META-INF/notice.txt",
-                            "spring-core-3.2.3.RELEASE.jar/META-INF/license.txt"
+                            "org.springframework_spring-core_3.2.3.RELEASE/META-INF/notice.txt",
+                            "org.springframework_spring-core_3.2.3.RELEASE/META-INF/license.txt"
                         ]
                     }
                 ],
@@ -678,18 +678,18 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                         "fileDetails": [
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt",
+                                "file": "org.springframework_spring-tx_3.2.3.RELEASE/META-INF/license.txt",
                                 "license": "Apache License, Version 2.0"
                             },
                             {
                                 "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0",
-                                "file": "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
+                                "file": "org.springframework_spring-tx_3.2.3.RELEASE/META-INF/notice.txt",
                                 "license": "Apache License, Version 2.0"
                             }
                         ],
                         "files": [
-                            "spring-tx-3.2.3.RELEASE.jar/META-INF/notice.txt",
-                            "spring-tx-3.2.3.RELEASE.jar/META-INF/license.txt"
+                            "org.springframework_spring-tx_3.2.3.RELEASE/META-INF/notice.txt",
+                            "org.springframework_spring-tx_3.2.3.RELEASE/META-INF/license.txt"
                         ]
                     }
                 ],

--- a/src/test/groovy/com/github/jk1/license/render/DownloadLicensesRendererFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/DownloadLicensesRendererFuncSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.render
+
+import com.github.jk1.license.AbstractGradleRunnerFunctionalSpec
+import org.gradle.testkit.runner.TaskOutcome
+
+class DownloadLicensesRendererFuncSpec extends AbstractGradleRunnerFunctionalSpec {
+    def setup() {
+        buildFile << """
+            import com.github.jk1.license.render.*
+
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+            }
+            
+            apply plugin: 'java'
+
+            repositories {
+                mavenCentral()
+            }
+
+            licenseReport {
+                outputDir = "$outputDir.absolutePath"
+                renderers = new DownloadLicensesRenderer()
+            }
+        """
+    }
+
+    def "it stores the licenses of a jar-file and download licenses from manifest or pom into the output-dir"() {
+        buildFile << """
+            dependencies {
+                compile "org.apache.commons:commons-lang3:3.7" // has NOTICE.txt and LICENSE.txt and downloaded licenses files
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt").exists()
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt").exists()
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/DOWNLOADED-MANIFEST-LICENSES/LICENSE_2_0_txt.txt").exists()
+        new File(outputDir, "org.apache.commons_commons-lang3_3.7/DOWNLOADED-POM-LICENSES/Apache_License_Version_2_0.txt").exists()
+        new File(outputDir, "automatic-included-license-files-report.json").text ==
+        """{
+    "noLicenseFileDependencies": [
+        
+    ],
+    "noLicenseFileImportedModules": [
+        
+    ],
+    "downloadedHtmlLicenseFileDirectories": [
+        
+    ],
+    "downloadedTextLicenseFileDirectories": [
+        "org.apache.commons_commons-lang3_3.7/DOWNLOADED-MANIFEST-LICENSES/LICENSE_2_0_txt.txt",
+        "org.apache.commons_commons-lang3_3.7/DOWNLOADED-POM-LICENSES/Apache_License_Version_2_0.txt"
+    ],
+    "embeddedLicenseFileDirectories": [
+        "org.apache.commons_commons-lang3_3.7/META-INF/LICENSE.txt",
+        "org.apache.commons_commons-lang3_3.7/META-INF/NOTICE.txt"
+    ]
+}"""
+        new File(outputDir, "automatic-included-license-html-files-contents.html").text ==
+        """"""
+
+
+    }
+
+    def "it stores the licenses of a jar-file and embedded manifest license into the output-dir"() {
+        buildFile << """
+            dependencies {
+                compile 'org.ehcache:ehcache:3.3.1' // has NOTICE.txt and LICENSE.txt and embedded manifest license
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        new File(outputDir, "org.ehcache_ehcache_3.3.1/EMBEDDED-MANIFEST-LICENSES/LICENSE").exists()
+        new File(outputDir, "org.ehcache_ehcache_3.3.1/LICENSE").exists()
+        new File(outputDir, "org.ehcache_ehcache_3.3.1/NOTICE").exists()
+        new File(outputDir, "org.slf4j_slf4j-api_1.7.7/DOWNLOADED-POM-LICENSES/MIT_License.html").exists()
+        new File(outputDir, "automatic-included-license-files-report.json").text ==
+        """{
+    "noLicenseFileDependencies": [
+        
+    ],
+    "noLicenseFileImportedModules": [
+        
+    ],
+    "downloadedHtmlLicenseFileDirectories": [
+        "org.ehcache_ehcache_3.3.1/DOWNLOADED-MANIFEST-LICENSES/LICENSE.html",
+        "org.slf4j_slf4j-api_1.7.7/DOWNLOADED-POM-LICENSES/MIT_License.html"
+    ],
+    "downloadedTextLicenseFileDirectories": [
+        "org.ehcache_ehcache_3.3.1/DOWNLOADED-POM-LICENSES/The_Apache_Software_License_Version_2_0.txt"
+    ],
+    "embeddedLicenseFileDirectories": [
+        "org.ehcache_ehcache_3.3.1/EMBEDDED-MANIFEST-LICENSES/LICENSE",
+        "org.ehcache_ehcache_3.3.1/LICENSE",
+        "org.ehcache_ehcache_3.3.1/NOTICE"
+    ]
+}"""
+        new File(outputDir, "automatic-included-license-html-files-contents.html").text ==
+        """<html><body><div><a href = "LICENSE">LICENSE</a></div></body></html>
+<html><body><div><a href = "http://www.opensource.org/licenses/mit-license.php">http://www.opensource.org/licenses/mit-license.php</a></div></body></html>
+"""
+
+    }
+
+}


### PR DESCRIPTION
This is a renderer that can download the license files from the internet if there is a valid licenseUrl.
If there is a licenseUrl is not valid. It will generate an HTML file only contains the link of it.
After downloading all the files, it will generate a report for the license file which is downloaded, embedded, an HTML file, or it doesn't have any license files.