### PR TITLE
Add license name headings to imported license bundle sections

### DIFF
--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -279,7 +279,7 @@ class InventoryHtmlReportRenderer implements ReportRenderer {
         externalInventories.keySet().sort().each { String name ->
             output << "<h1>${name}</h1>\n"
             externalInventories[name].each { String license, List<ImportedModuleData> dependencies ->
-                output << "<a id='${sanitize(name, license)}'></a>\n"
+                output << "<a id='${sanitize(name, license)}'></a>\n" << "<h2>${license}</h2>\n"
                 dependencies.each { ImportedModuleData importedData ->
                     printImportedDependency(importedData)
                 }


### PR DESCRIPTION
Add license name headings to imported license bundle sections in `InventoryHtmlReportRenderer`.

`InventoryHtmlReportRenderer` outputs a heading for each license in the inventory, but currently it does not print the header when outputting the imported module bundles.