### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+install: true
+script:
+  - ./gradlew --scan build

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,17 @@
 plugins {
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'idea'
     id 'groovy'
     id 'maven-publish'
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'com.gradle.plugin-publish' version '0.10.1'
     id "com.palantir.idea-test-fix" version "0.1.0"
     id "com.github.hierynomus.license" version"0.15.0"
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 group = "com.github.jk1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.