### PR TITLE
Treat default configuration in the normalizer right

### DIFF
--- a/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
@@ -79,4 +79,9 @@ abstract class AbstractGradleRunnerFunctionalSpec extends Specification {
         }
     }
 
+    // When a path is used in a gradle build script, a single backslash breaks the script.
+    // Therefore to avoid any problems, a normal slash is used (and it seems to work)
+    static String fixPathForBuildFile(String path) {
+        return path.replaceAll("\\\\", "/")
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
+++ b/src/test/groovy/com/github/jk1/license/PluginCompatibilityTest.groovy
@@ -23,6 +23,8 @@ import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static com.github.jk1.license.AbstractGradleRunnerFunctionalSpec.fixPathForBuildFile
+
 class PluginCompatibilityTest extends Specification {
     private final static def supportedGradleVersions = [ "3.3", "3.5.1", "4.0.1", "4.6", "4.7", "4.8", "4.9", "4.10", "5.0", "5.1", "5.2" ]
     private final static def unsupportedGradleVersions = [ "3.2" ]
@@ -57,7 +59,7 @@ class PluginCompatibilityTest extends Specification {
             import com.github.jk1.license.filter.*
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 filters = [ new LicenseBundleNormalizer() ]
                 renderers = [ new InventoryHtmlReportRenderer('report.html','Backend'), new JsonReportRenderer(onlyOneLicensePerModule: false) ]
                 configurations = ALL

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerFuncSpec.groovy
@@ -18,7 +18,6 @@ package com.github.jk1.license.filter
 import com.github.jk1.license.AbstractGradleRunnerFunctionalSpec
 import org.gradle.testkit.runner.TaskOutcome
 
-import static com.github.jk1.license.reader.ProjectReaderFuncSpec.prettyPrintJson
 import static com.github.jk1.license.reader.ProjectReaderFuncSpec.removeDevelopers
 
 class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec {
@@ -46,8 +45,8 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             import com.github.jk1.license.render.*
             import com.github.jk1.license.reader.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
-                filters = new LicenseBundleNormalizer(bundlePath: "$normalizerFile.absolutePath", createDefaultTransformationRules: false)
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
+                filters = new LicenseBundleNormalizer(bundlePath: "${fixPathForBuildFile(normalizerFile.absolutePath)}", createDefaultTransformationRules: false)
                 renderer = new MultiReportRenderer(new JsonReportRenderer(onlyOneLicensePerModule: false), new RawProjectDataJsonRenderer())
                 configurations = ['forTesting']
             }
@@ -169,7 +168,7 @@ class LicenseBundleNormalizerFuncSpec extends AbstractGradleRunnerFunctionalSpec
             import com.github.jk1.license.filter.*
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$licenseResultJsonFile.parentFile.absolutePath"
+                outputDir = "${fixPathForBuildFile(licenseResultJsonFile.parentFile.absolutePath)}"
                 filters = new LicenseBundleNormalizer()
                 renderer = new JsonReportRenderer(onlyOneLicensePerModule: false)
                 configurations = ['forTesting']

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -523,7 +523,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                         pom("pom1") {
                             license(APACHE2_LICENSE(), url: "different url")
                             // should be normalized because name matches the bundle-name
-                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            license(APACHE2_LICENSE(), name: "Apache -2.0", url: "different url")
                             // should stay, because name is different
                         }
                     }
@@ -536,7 +536,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                     module("mod1") {
                         pom("pom1") {
                             license(APACHE2_LICENSE())
-                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            license(APACHE2_LICENSE(), name: "Apache -2.0", url: "different url")
                         }
                     }
                 }
@@ -560,7 +560,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                         pom("pom1") {
                             license(APACHE2_LICENSE(), name: "different name")
                             // should be normalized because url matches the bundle-url
-                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            license(APACHE2_LICENSE(), name: "Apache -2.0", url: "different url")
                             // should stay, because url is different
                         }
                     }
@@ -573,7 +573,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                     module("mod1") {
                         pom("pom1") {
                             license(APACHE2_LICENSE())
-                            license(APACHE2_LICENSE(), name: "Apache 2.0", url: "different url")
+                            license(APACHE2_LICENSE(), name: "Apache -2.0", url: "different url")
                         }
                     }
                 }

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -38,7 +38,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = []
             }
@@ -343,7 +343,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 projects = [project]
                 renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = []
@@ -450,7 +450,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = []
             }
@@ -551,7 +551,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = ['mainConfig']
             }

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -37,7 +37,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
 
             import com.github.jk1.license.render.*
             licenseReport {
-                outputDir = "$outputDir.absolutePath"
+                outputDir = "${fixPathForBuildFile(outputDir.absolutePath)}"
                 renderer = new com.github.jk1.license.render.RawProjectDataJsonRenderer()
                 configurations = ['forTesting']
             }


### PR DESCRIPTION
Fixed a few things:
* The flag `createDefaultTransformationRules` in the `LicenseBundleNormalizer` now also has an effect on the default license bundle. So when the flag is turned on, the rules of the file are applied additionally to the a provided license bundle file.
* Caching in the `LicenseBundleNormalizer` was improved. Now all inputs are considered
* Allow tests run also on Windows.