### PR TITLE
configuration option to disable transitive dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ licenseReport {
 
     // Don't include artifacts of project's own group into the report
     excludeOwnGroup = true
+    
+    // Include transitive dependencies into the report
+    includeTransitiveDeps = true
 
     // Set custom report renderer, implementing ReportRenderer.
     // Yes, you can write your own to support any format necessary.

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -34,6 +34,7 @@ class LicenseReportExtension {
     public DependencyDataImporter[] importers
     public DependencyFilter[] filters
     public String[] configurations
+    public boolean includeTransitiveDeps
     public boolean excludeOwnGroup
     public String[] excludeGroups
     public String[] excludes
@@ -44,6 +45,7 @@ class LicenseReportExtension {
         projects = [project] + project.subprojects
         renderers = new SimpleHtmlReportRenderer()
         configurations = ['runtimeClasspath']
+        includeTransitiveDeps = true
         excludeOwnGroup = true
         excludeGroups = []
         excludes = []
@@ -64,6 +66,8 @@ class LicenseReportExtension {
         snapshot += filters.collect { it.class.name }
         snapshot << 'configurations '
         snapshot += configurations
+        snapshot << 'includeTransitiveDeps'
+        snapshot += includeTransitiveDeps
         snapshot << 'excludeOwnGroup'
         snapshot += excludeOwnGroup
         snapshot << 'exclude'

--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -74,7 +74,9 @@ class ConfigurationReader {
                 LOGGER.debug("Collecting dependency ${root.name}")
                 accumulator.add(root)
             }
-            root.children.each { collectDependencies(accumulator, visitedExcludes, it)}
+            if (config.includeTransitiveDeps) {
+                root.children.each { collectDependencies(accumulator, visitedExcludes, it) }
+            }
         }
         accumulator
     }


### PR DESCRIPTION
In this PR I've added configuration option to print only direct dependencies.
Maybe it will be useful also for someone else.