### PR TITLE
Always match bundle names in LicenseBundleNormalizer

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -66,8 +66,8 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (createDefaultTransformationRules) {
             applyDefaultNormalizerBundleFile()
-            applyBundleNamesAndUrlsAsExactMatchRules()
         }
+        applyBundleNamesAndUrlsAsExactMatchRules()
 
         LOGGER.debug("Bundle normalizer initialized (Bundles: ${normalizerConfig.bundles.size()}, Rules: ${normalizerConfig.transformationRules.size()})")
     }


### PR DESCRIPTION
If the bundle name matches exactly, it makes sense to match,
even if createDefaultTransformationRules is false.