### PR TITLE
Transform license bundles faster by using @CompileStatic and precompiled java.util.regex.Pattern instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildScan {
 }
 
 group = "com.github.jk1"
-version = "1.7"
+version = "1.8-SNAPSHOT"
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -392,9 +392,9 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         NormalizerTransformationRuleMatcher(NormalizerTransformationRule rule) {
             this.rule = rule
-            licenseNameRegex = rule.licenseNamePattern != null ? Pattern.compile(rule.licenseNamePattern) : null
-            licenseUrlRegex = rule.licenseUrlPattern != null ? Pattern.compile(rule.licenseUrlPattern) : null
-            licenseFileContentRegex = rule.licenseFileContentPattern != null ? Pattern.compile(rule.licenseFileContentPattern) : null
+            licenseNameRegex = rule.licenseNamePattern != null ? Pattern.compile(rule.licenseNamePattern, Pattern.MULTILINE | Pattern.DOTALL) : null
+            licenseUrlRegex = rule.licenseUrlPattern != null ? Pattern.compile(rule.licenseUrlPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
+            licenseFileContentRegex = rule.licenseFileContentPattern != null ? Pattern.compile(rule.licenseFileContentPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
             moduleRegex = rule.modulePattern != null ? Pattern.compile(rule.modulePattern) : null
         }
 

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -82,10 +82,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
         LOGGER.debug("Performing module license normalization")
         config = data.project.licenseReport
 
-        // Make java.util.Pattern out of the regular expressions, so the pattern matching is quicker
-        List<NormalizerTransformationRuleMatcher> transformationRuleMatchers = normalizerConfig.transformationRules.collect{
-            NormalizerTransformationRule rule -> new NormalizerTransformationRuleMatcher(rule)
-        }
+        List<NormalizerTransformationRuleMatcher> transformationRuleMatchers = makeNormalizerTransformationRuleMatchers(normalizerConfig.transformationRules)
 
         LOGGER.debug("Normalizing pom.xml license section...")
         data.configurations*.dependencies.flatten().forEach { normalizePoms(transformationRuleMatchers, it) }
@@ -182,28 +179,24 @@ class LicenseBundleNormalizer implements DependencyFilter {
         importedModuleBundle.modules.addAll(normalizedModuleData)
     }
 
-    @CompileStatic
     private Collection<License> normalizePomLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                                     License license,
                                                     String module) {
-        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers, module, license.name, license.url)
+        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
+                module, license.name, license.url, {null})
 
         LOGGER.debug("License {} ({}) matches the following rules: [{}]", license.name, license.url, rules.join(","))
 
         if (rules.isEmpty()) return [license]
 
-        List<License> normalized = new ArrayList<>()
-        for (NormalizerTransformationRule rule : rules) {
-            normalized.add(normalizeSinglePomLicense(rule, license))
-        }
-        return normalized
+        rules.collect { normalizeSinglePomLicense(it, license) }
     }
 
-    @CompileStatic
     private Collection<ManifestData> normalizeManifestLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                                               ManifestData manifest,
                                                               String module) {
-        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers, module, manifest.license, manifest.license)
+        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
+                module, manifest.license, manifest.license, {null})
 
         LOGGER.debug("License {} ({}) (via manifest data, module {}) matches the following rules: [{}]",
                 module,
@@ -212,31 +205,17 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [manifest]
 
-        List<ManifestData> normalized = new ArrayList<>()
-        for (NormalizerTransformationRule rule : rules) {
-            normalized.add(normalizeSingleManifestLicense(rule, manifest))
-        }
-        return normalized
+        rules.collect { normalizeSingleManifestLicense(it, manifest) }
     }
 
-    @CompileStatic
     private Collection<LicenseFileDetails> normalizeLicenseFileDetailsLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                                                               LicenseFileDetails licenseFileDetails,
                                                                               String module) {
         if (licenseFileDetails.file == null || licenseFileDetails.file.isEmpty()) return [licenseFileDetails]
 
-        // Only read the license text file once
-        def licenseFileContent = { new File("$config.outputDir/$licenseFileDetails.file").text }.memoize()
-
-        List<NormalizerTransformationRule> rules = new ArrayList<>()
-        for (NormalizerTransformationRuleMatcher matcher : transformationRuleMatchers) {
-            if (matcher.moduleMatches(module) ||
-                    matcher.licenseNameMatches(licenseFileDetails.license) ||
-                    matcher.licenseUrlMatches(licenseFileDetails.licenseUrl) ||
-                    matcher.licenseFileContentMatches(licenseFileContent())) {
-                rules.add(matcher.rule)
-            }
-        }
+        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
+                module, licenseFileDetails.license, licenseFileDetails.licenseUrl,
+                { new File("$config.outputDir/$licenseFileDetails.file").text }.memoize())
 
         LOGGER.debug("License {} ({}) (via license file details, module {}) matches the following rules: [{}]",
                 module,
@@ -245,19 +224,15 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [licenseFileDetails]
 
-        List<LicenseFileDetails> normalized = new ArrayList<>()
-        for (NormalizerTransformationRule rule : rules) {
-            normalized.add(normalizeSingleLicenseFileDetailsLicense(rule, licenseFileDetails))
-        }
-        return normalized
+        rules.collect { normalizeSingleLicenseFileDetailsLicense(it, licenseFileDetails) }
     }
 
-    @CompileStatic
     private Collection<ImportedModuleData> normalizeModuleData(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                                                ImportedModuleData importedModuleData) {
         String module = importedModuleData.name + ':' + importedModuleData.version
 
-        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers, module, importedModuleData.license, importedModuleData.licenseUrl)
+        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
+                module, importedModuleData.license, importedModuleData.licenseUrl, {null})
 
         LOGGER.debug("License {} ({}) (via imported module data {}:{}) matches the following rules: [{}]",
                 importedModuleData.license, importedModuleData.licenseUrl,
@@ -266,25 +241,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [importedModuleData]
 
-        List<ImportedModuleData> normalized = new ArrayList<>()
-        for (NormalizerTransformationRule rule : rules) {
-            normalized.add(normalizeSingleModuleDataLicense(rule, importedModuleData))
-        }
-        return normalized
-    }
-
-    @CompileStatic
-    private static List<NormalizerTransformationRule> transformationRulesFor(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
-                                                                             String module, String license, String licenseUrl) {
-        List<NormalizerTransformationRule> rules = new ArrayList<>()
-        for (NormalizerTransformationRuleMatcher matcher : transformationRuleMatchers) {
-            if (matcher.moduleMatches(module) ||
-                    matcher.licenseNameMatches(license) ||
-                    matcher.licenseUrlMatches(licenseUrl)) {
-                rules.add(matcher.rule)
-            }
-        }
-        return rules
+        rules.collect { normalizeSingleModuleDataLicense(it, importedModuleData) }
     }
 
     @CompileStatic
@@ -376,9 +333,47 @@ class LicenseBundleNormalizer implements DependencyFilter {
     }
 
     /**
+     * Central function that performs the actual pattern matching using the
+     * {@link NormalizerTransformationRuleMatcher} instances computed from the model's
+     * {@link NormalizerTransformationRule}.
+     *
+     * @param transformationRuleMatchers the matcher instances
+     * @param module Artifact coordinates in the form {@code group:name:version}
+     * @param license License name(s), may contain newlines, spaces (unfortunately). May also contain multiple license names (undefined separator)
+     * @param licenseUrl License URL(s), may contain newlines, spaces (unfortunately). May also contain multiple license names (undefined separator)
+     * @param licenseContent License content text. May contain multiple licenses.
+     * @return list of matching rules
+     */
+    @CompileStatic
+    static List<NormalizerTransformationRule> transformationRulesFor(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
+                                                                     String module, String license, String licenseUrl,
+                                                                     Closure<String> licenseContent) {
+        List<NormalizerTransformationRule> rules = new ArrayList<>()
+        for (NormalizerTransformationRuleMatcher matcher : transformationRuleMatchers) {
+            if (matcher.moduleMatches(module) ||
+                    matcher.licenseNameMatches(license) ||
+                    matcher.licenseUrlMatches(licenseUrl) ||
+                    matcher.licenseFileContentMatches(licenseContent)) {
+                rules.add(matcher.rule)
+            }
+        }
+        return rules
+    }
+
+    static List<NormalizerTransformationRuleMatcher> makeNormalizerTransformationRuleMatchers(List<NormalizerTransformationRule> normalizerTransformationRules) {
+        // Make java.util.Pattern out of the regular expressions, so the pattern matching is quicker
+        normalizerTransformationRules.collect{
+            NormalizerTransformationRule rule -> new NormalizerTransformationRuleMatcher(rule)
+        }
+    }
+
+    /**
      * Takes a {@link NormalizerTransformationRule}, builds {@link Pattern} instances from the {@code *Pattern} fields
      * in {@code NormalizerTransformationRule} used to do the actual regex pattern matching (if the exact string
      * matching fails).
+     *
+     * Matching on a specific field (license name, license URL, license file content, module name) is only
+     * performed, when the pattern is not {@code null} and not empty.
      *
      * This class is only used during the actual filtering process but not kept around in the model.
      */
@@ -392,26 +387,49 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         NormalizerTransformationRuleMatcher(NormalizerTransformationRule rule) {
             this.rule = rule
-            licenseNameRegex = rule.licenseNamePattern != null ? Pattern.compile(rule.licenseNamePattern, Pattern.MULTILINE | Pattern.DOTALL) : null
-            licenseUrlRegex = rule.licenseUrlPattern != null ? Pattern.compile(rule.licenseUrlPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
-            licenseFileContentRegex = rule.licenseFileContentPattern != null ? Pattern.compile(rule.licenseFileContentPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
-            moduleRegex = rule.modulePattern != null ? Pattern.compile(rule.modulePattern) : null
+            licenseNameRegex = rule.licenseNamePattern != null && !rule.licenseNamePattern.isEmpty() ? Pattern.compile(rule.licenseNamePattern, Pattern.MULTILINE | Pattern.DOTALL) : null
+            licenseUrlRegex = rule.licenseUrlPattern != null && !rule.licenseUrlPattern.isEmpty() ? Pattern.compile(rule.licenseUrlPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
+            licenseFileContentRegex = rule.licenseFileContentPattern != null && !rule.licenseFileContentPattern.isEmpty() ? Pattern.compile(rule.licenseFileContentPattern, Pattern.MULTILINE | Pattern.DOTALL) : null
+            moduleRegex = rule.modulePattern != null && !rule.modulePattern.isEmpty() ? Pattern.compile(rule.modulePattern) : null
         }
 
         boolean licenseNameMatches(String name) {
-            return name != null && licenseNameRegex != null && (rule.licenseNamePattern == name || licenseNameRegex.matcher(name).matches())
+            if (name == null || licenseNameRegex == null)
+                return false
+            name = name.trim()
+            if (name.isEmpty())
+                return false
+            return rule.licenseNamePattern == name || licenseNameRegex.matcher(name).matches()
         }
 
         boolean licenseUrlMatches(String url) {
-            return url != null && licenseUrlRegex != null && (rule.licenseUrlPattern == url || licenseUrlRegex.matcher(url).matches())
+            if (url == null || licenseUrlRegex == null)
+                return false
+            url = url.trim()
+            if (url.isEmpty())
+                return false
+            return rule.licenseUrlPattern == url || licenseUrlRegex.matcher(url).matches()
         }
 
-        boolean licenseFileContentMatches(String content) {
-            return content != null && licenseFileContentRegex != null && (rule.licenseFileContentPattern == content || licenseFileContentRegex.matcher(content).matches())
+        boolean licenseFileContentMatches(Closure<String> contentClosure) {
+            if (contentClosure == null || licenseFileContentRegex == null)
+                return false
+            String content = contentClosure()
+            if (content == null)
+                return false
+            content = content.trim()
+            if (content.isEmpty())
+                return false
+            return rule.licenseFileContentPattern == content || licenseFileContentRegex.matcher(content).matches()
         }
 
         boolean moduleMatches(String module) {
-            return module != null && moduleRegex != null && (rule.modulePattern == module || moduleRegex.matcher(module).matches())
+            if (module == null || moduleRegex == null)
+                return false
+            module = module.trim()
+            if (module.isEmpty())
+                return false
+            return rule.modulePattern == module || moduleRegex.matcher(module).matches()
         }
     }
 

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -192,7 +192,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [license]
 
-        rules.collect { normalizeSinglePomLicense(it, license) }
+        List<License> normalized = new ArrayList<>()
+        for (NormalizerTransformationRule rule : rules) {
+            normalized.add(normalizeSinglePomLicense(rule, license))
+        }
+        return normalized
     }
 
     @CompileStatic
@@ -208,7 +212,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [manifest]
 
-        rules.collect { normalizeSingleManifestLicense(it, manifest) }
+        List<ManifestData> normalized = new ArrayList<>()
+        for (NormalizerTransformationRule rule : rules) {
+            normalized.add(normalizeSingleManifestLicense(rule, manifest))
+        }
+        return normalized
     }
 
     @CompileStatic
@@ -237,7 +245,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [licenseFileDetails]
 
-        rules.collect { normalizeSingleLicenseFileDetailsLicense(it, licenseFileDetails) }
+        List<LicenseFileDetails> normalized = new ArrayList<>()
+        for (NormalizerTransformationRule rule : rules) {
+            normalized.add(normalizeSingleLicenseFileDetailsLicense(rule, licenseFileDetails))
+        }
+        return normalized
     }
 
     @CompileStatic
@@ -254,7 +266,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [importedModuleData]
 
-        rules.collect { normalizeSingleModuleDataLicense(it, importedModuleData) }
+        List<ImportedModuleData> normalized = new ArrayList<>()
+        for (NormalizerTransformationRule rule : rules) {
+            normalized.add(normalizeSingleModuleDataLicense(rule, importedModuleData))
+        }
+        return normalized
     }
 
     @CompileStatic


### PR DESCRIPTION
The normalization of licenses can take a significant amount of time when a lot (some hundred) dependencies are involved.

Using `@CompileStatic` on (some) hot code paths and using precompiled `java.util.regex.Pattern` instances gives a 4x preformance improvement. In my case, it's a speed-up of 15 seconds.

Also adds a new `modulePattern` to `NormalizerTransformationRule` (within the elements in the `transformationRules` JSON node) to map some ancient modules, that don't have any license information.