### PR TITLE
Better license mapping from manifest and via transformations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildScan {
 }
 
 group = "com.github.jk1"
-version = "1.8"
+version = "1.9-SNAPSHOT"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -50,7 +50,7 @@ class ModuleData {
 @Sortable
 @Canonical
 class ManifestData {
-    String name, version, description, vendor, license, url
+    String name, version, description, vendor, url, license, licenseUrl
     boolean hasPackagedLicense
 }
 

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -196,11 +196,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
                                                               ManifestData manifest,
                                                               String module) {
         List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
-                module, manifest.license, manifest.license, {null})
+                module, manifest.license, manifest.licenseUrl, {null})
 
         LOGGER.debug("License {} ({}) (via manifest data, module {}) matches the following rules: [{}]",
-                module,
                 manifest.name, manifest.url,
+                module,
                 rules.join(","))
 
         if (rules.isEmpty()) return [manifest]
@@ -218,8 +218,8 @@ class LicenseBundleNormalizer implements DependencyFilter {
                 { new File("$config.outputDir/$licenseFileDetails.file").text }.memoize())
 
         LOGGER.debug("License {} ({}) (via license file details, module {}) matches the following rules: [{}]",
-                module,
                 licenseFileDetails.license, licenseFileDetails.licenseUrl,
+                module,
                 rules.join(","))
 
         if (rules.isEmpty()) return [licenseFileDetails]
@@ -271,12 +271,16 @@ class LicenseBundleNormalizer implements DependencyFilter {
             description: manifest.description,
             vendor: manifest.vendor,
             license: manifest.license,
+            licenseUrl: manifest.licenseUrl,
             url: manifest.url,
             hasPackagedLicense: manifest.hasPackagedLicense
         )
 
         normalizeWithBundle(rule) { NormalizerLicenseBundle bundle ->
-            if (rule.transformName) normalized.license = bundle.licenseName
+            if (rule.transformName)
+                normalized.license = bundle.licenseName
+            if (rule.transformUrl)
+                normalized.licenseUrl = bundle.licenseUrl
         }
         normalized
     }

--- a/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
@@ -89,9 +89,15 @@ class ManifestReader {
         data.name = attr.getValue('Bundle-Name') ?: attr.getValue('Implementation-Title') ?: attr.getValue('Bundle-SymbolicName')
         data.version = attr.getValue('Bundle-Version') ?: attr.getValue('Implementation-Version') ?: attr.getValue('Specification-Version')
         data.description = attr.getValue('Bundle-Description')
-        data.license = attr.getValue('Bundle-License')
+        String bundleLicense = attr.getValue('Bundle-License')
         data.vendor = attr.getValue('Bundle-Vendor') ?: attr.getValue('Implementation-Vendor')
         data.url = attr.getValue('Bundle-DocURL')
+        if (Files.maybeLicenseUrl(bundleLicense)) {
+            data.licenseUrl = bundleLicense
+        }
+        else {
+            data.license = bundleLicense
+        }
         LOGGER.info("Returning manifest data: " + data.dump())
         return data
     }

--- a/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
@@ -22,6 +22,7 @@ import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.PomData
 import com.github.jk1.license.ProjectData
+import com.github.jk1.license.util.Files
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 
@@ -132,11 +133,11 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
                     "\n        </p>"
             }
             if (manifest.license) {
-                if (manifest.license.startsWith("http")) {
+                if (Files.maybeLicenseUrl(manifest.licenseUrl)) {
                     output << "" +
                         "\n        <p>" +
                         "\n            <strong>Manifest license URL:</strong>" +
-                        "\n            <a href=\"$manifest.license\">" +
+                        "\n            <a href=\"$manifest.licenseUrl\">" +
                         "\n                $manifest.license" +
                         "\n            </a>" +
                         "\n        </p>"
@@ -176,7 +177,7 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
                         "\n        <p>" +
                         "\n            <strong>POM License: $license.name</strong>"
                     if (license.url) {
-                        if (license.url.startsWith("http")) {
+                        if (Files.maybeLicenseUrl(license.url)) {
                             output << "" +
                                 "\n            - " +
                                 "\n            <a href=\"$license.url\">" +
@@ -219,7 +220,7 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
         output << "" +
             "\n        </p>"
 
-        if (module.projectUrl?.startsWith("http")) {
+        if (Files.maybeLicenseUrl(module.projectUrl)) {
             output << "" +
                 "\n        <p>" +
                 "\n            <strong>Project URL:</strong>" +
@@ -231,7 +232,7 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
                 "\n        </p>"
         }
 
-        if (module.licenseUrl?.startsWith("http")) {
+        if (Files.maybeLicenseUrl(module.licenseUrl)) {
             output << "" +
                 "\n        <p>" +
                 "\n            <strong>License:</strong> $module.license - " +

--- a/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
@@ -21,6 +21,7 @@ import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.PomData
 import com.github.jk1.license.ProjectData
+import com.github.jk1.license.util.Files
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 
@@ -87,8 +88,8 @@ This report was generated at ${new Date()}.
                 output << "Manifest Project URL: $manifest.url\n\n"
             }
             if (manifest.license) {
-                if (manifest.license.startsWith("http")) {
-                    output << "Manifest license URL: $manifest.license\n\n"
+                if (Files.maybeLicenseUrl(manifest.licenseUrl)) {
+                    output << "Manifest license URL: $manifest.licenseUrl\n\n"
                 } else if (manifest.hasPackagedLicense) {
                     output << "Packaged License File: $manifest.license\n\n"
                 } else {
@@ -106,7 +107,7 @@ This report was generated at ${new Date()}.
                 pomData.licenses.each { License license ->
                     output << "POM License: $license.name"
                     if (license.url) {
-                        if (license.url.startsWith("http")) {
+                        if (Files.maybeLicenseUrl(license.url)) {
                             output << " - $license.url\n\n"
                         } else {
                             output << "License: $license.url\n\n"

--- a/src/main/groovy/com/github/jk1/license/util/Files.groovy
+++ b/src/main/groovy/com/github/jk1/license/util/Files.groovy
@@ -23,4 +23,8 @@ class Files {
         int dotIndex = fileName.lastIndexOf('.')
         return (dotIndex == -1) ? "" : fileName.substring(dotIndex + 1)
     }
+
+    static boolean maybeLicenseUrl(String url) {
+        return url != null && (url.startsWith("http:") || url.startsWith("https:"))
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/PluginSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/PluginSpec.groovy
@@ -28,7 +28,7 @@ import static com.github.jk1.license.AbstractGradleRunnerFunctionalSpec.fixPathF
 
 class PluginSpec extends Specification {
 
-    private final static def supportedGradleVersions = [ "3.3", "3.5.1", "4.0.1", "4.6", "4.7", "4.8", "4.9", "4.10", "5.0", "5.1", "5.2" ]
+    private final static def supportedGradleVersions = [ "3.3", "3.5.1", "4.0.1", "4.6", "4.7", "4.8", "4.9", "4.10", "5.0", "5.1", "5.2", "5.5" ]
     private final static def unsupportedGradleVersions = [ "3.2" ]
 
     @Rule
@@ -99,12 +99,12 @@ class PluginSpec extends Specification {
             ],
             "moduleLicenses": [
                 {
-                    "moduleLicense": null,
-                    "moduleLicenseUrl": "LICENSE"
-                },
-                {
                     "moduleLicense": "Apache License, Version 2.0",
                     "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                },
+                {
+                    "moduleLicense": "LICENSE",
+                    "moduleLicenseUrl": null
                 }
             ]
         },

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license
 
+import com.github.jk1.license.util.Files
 import groovy.json.JsonBuilder
 
 import static com.github.jk1.license.ProjectDataFixture.GRADLE_PROJECT
@@ -180,7 +181,14 @@ class ProjectBuilder extends BuilderSupport {
         if (current instanceof PomData) {
             addPomLicense(license, map)
         } else if (current instanceof ManifestData) {
-            addManifestLicense(license)
+            if (license != null)
+                addManifestLicense(license)
+            else {
+                if (map['name'])
+                    current.license = map['name']
+                if (map['url'])
+                    current.licenseUrl = map['url']
+            }
         } else {
             throw new IllegalAccessException("current must be PomData or ManifestData not $current")
         }
@@ -218,8 +226,13 @@ class ProjectBuilder extends BuilderSupport {
         } else {
             throw new IllegalArgumentException("license must be a License or a String but is $license")
         }
-
-        manifest.license = licenseText
+        if (Files.maybeLicenseUrl(licenseText)) {
+            manifest.license = null // initialized to "Apache 2.0" above
+            manifest.licenseUrl = licenseText
+        }
+        else {
+            manifest.license = licenseText
+        }
     }
 
     private static def enhanceLicenseAboutValues(License license, Map map) {

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilderSpec.groovy
@@ -186,7 +186,7 @@ class ProjectBuilderSpec extends Specification {
 
         data.configurations*.dependencies.flatten().manifests.flatten().find { it.name == "mani1" }*.license == [APACHE2_LICENSE().name]
         data.configurations*.dependencies.flatten().manifests.flatten().find { it.name == "mani2" }*.license == [MIT_LICENSE().name]
-        data.configurations*.dependencies.flatten().manifests.flatten().find { it.name == "mani3" }*.license == [LGPL_LICENSE().url]
+        data.configurations*.dependencies.flatten().manifests.flatten().find { it.name == "mani3" }*.licenseUrl == [LGPL_LICENSE().url]
 
         data.importedModules.isEmpty()
     }

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -76,7 +76,7 @@ class LicenseBundleNormalizerSpec extends Specification {
         def result = newNormalizer().filter(buildProjectWithManifestLicense("Apache 2"))
 
         then:
-        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0"))
+        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"))
     }
 
     def "normalize license of manifest by checking license name for equality"() {
@@ -90,7 +90,7 @@ class LicenseBundleNormalizerSpec extends Specification {
         def result = newNormalizer().filter(buildProjectWithManifestLicense("Apache+2"))
 
         then:
-        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0"))
+        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"))
     }
 
     def "normalize the manifests license by matching license url"() {
@@ -101,10 +101,10 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         when:
-        def result = newNormalizer().filter(buildProjectWithManifestLicense("http://www.apache.org/licenses/LICENSE-3.0.txt"))
+        def result = newNormalizer().filter(buildProjectWithManifestLicense(null, "http://www.apache.org/licenses/LICENSE-3.0.txt"))
 
         then:
-        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0"))
+        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"))
     }
 
     def "normalize the manifests license by checking license url for equality"() {
@@ -115,19 +115,19 @@ class LicenseBundleNormalizerSpec extends Specification {
             }"""
 
         when:
-        def result = newNormalizer().filter(buildProjectWithManifestLicense("http://www.apache.org/licenses/LICENSE+2.0.txt"))
+        def result = newNormalizer().filter(buildProjectWithManifestLicense(null, "http://www.apache.org/licenses/LICENSE+2.0.txt"))
 
         then:
-        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0"))
+        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"))
     }
 
-    private ProjectData buildProjectWithManifestLicense(String name){
+    private ProjectData buildProjectWithManifestLicense(String name, String url = null){
         return builder.project {
             configurations(["runtime", "test"]) { configName ->
                 configuration(configName) {
                     module("mod1") {
                         manifest("mani1") {
-                            license(name)
+                            license(name: name, url: url)
                         }
                     }
                 }
@@ -183,7 +183,7 @@ class LicenseBundleNormalizerSpec extends Specification {
         def result = newNormalizer().filter(buildProjectWithManifestLicense("Apache 2"))
 
         then:
-        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0"))
+        json(result) == json(buildProjectWithManifestLicense("Apache License, Version 2.0", "https://www.apache.org/licenses/LICENSE-2.0"))
     }
 
     def "all bundles of all imported modules are normalized"() {
@@ -728,10 +728,10 @@ class LicenseBundleNormalizerSpec extends Specification {
                 configuration(configName) {
                     module("mod1") {
                         manifest("mani1") {
-                            license("MIT License")
+                            license(name: "MIT License", url: "https://opensource.org/licenses/MIT")
                         }
                         manifest("mani1") {
-                            license("Apache License, Version 2.0")
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }
                 }
@@ -774,7 +774,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                             license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
                         }
                         manifest("mani1") {
-                            license("Apache License, Version 2.0")
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }
                 }
@@ -835,7 +835,7 @@ class LicenseBundleNormalizerSpec extends Specification {
                             license("Apache 2.0 should not be matched")
                         }
                         manifest("mani2") {
-                            license("Apache License, Version 2.0")
+                            license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }
                 }

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -80,10 +80,11 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
+                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -131,6 +132,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.jetbrains",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
@@ -199,10 +201,11 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
+                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -255,10 +258,11 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
+                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -362,10 +366,11 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
+                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -459,6 +464,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.jetbrains",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -307,6 +307,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "aopalliance",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
@@ -342,6 +343,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "commons-logging",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": "Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "1.1.1",
@@ -393,10 +395,11 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.apache.commons",
                 "manifests": [
                     {
+                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -444,6 +447,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.ehcache",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
                         "hasPackagedLicense": true,
                         "version": "3.3.1",
@@ -495,6 +499,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.slf4j",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": "SLF4J.ORG",
                         "hasPackagedLicense": false,
                         "version": "1.7.7",
@@ -533,6 +538,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.springframework",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",
@@ -584,6 +590,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.springframework",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",
@@ -635,6 +642,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "org.springframework",
                 "manifests": [
                     {
+                        "licenseUrl": null,
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",


### PR DESCRIPTION
Some old artifacts have very little to no license information, so such dependencies
are mapped using a license-transformation rule using a `modulePattern`.
Although the pattern matches and the license bundle has the correct URL, the dependency
appears in the "Unknown" category in the `InventoryHtmlReportRenderer` without a link to the license content.

Example "bad" dependency, that needs such a mapping is `javax.servlet.jsp:jsp-api:2.1`.

The PR add a new field `licenseUrl` to `ManifestData` and therefore allows to have both the license name and license URL. When reading the manifest, probable URLs land in `licenseUrl` instead of `license`. Transformations then consider both fields independently.

Rather unrelated change: slightly enlarge the left navigation bar in `InventoryHtmlReportRenderer`.
