### PR TITLE
Run tests on Windows

### DIFF
--- a/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.check
 
+import groovy.json.StringEscapeUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -130,7 +131,7 @@ class CheckLicenseTaskSpec extends Specification {
             }
             licenseReport {
                 filters = new LicenseBundleNormalizer()
-                allowedLicensesFile = new File("${allowed.path}")
+                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(allowed.path)}")
             }
         """
 
@@ -205,7 +206,7 @@ class CheckLicenseTaskSpec extends Specification {
             }
             licenseReport {
                 filters = new LicenseBundleNormalizer()
-                allowedLicensesFile = new File("${allowed.path}")
+                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(allowed.path)}")
             }
         """
 
@@ -388,7 +389,7 @@ class CheckLicenseTaskSpec extends Specification {
                 kotlinOptions.jvmTarget = "1.8"
             }
             licenseReport {
-                allowedLicensesFile = new File("${allowed.path}")
+                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(allowed.path)}")
             }
         """
         buildResult = result("--build-cache", "checkLicense")
@@ -520,7 +521,7 @@ class CheckLicenseTaskSpec extends Specification {
                 kotlinOptions.jvmTarget = "1.8"
             }
             licenseReport {
-                allowedLicensesFile = new File("${allowed.path}")
+                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(allowed.path)}")
             }
         """
         buildResult = result("--build-cache", "checkLicense")

--- a/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
@@ -22,7 +22,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
-class CheckLicenseTaskSpec extends Specification{
+class CheckLicenseTaskSpec extends Specification {
     @Rule
     final TemporaryFolder testProjectDir = new TemporaryFolder()
 
@@ -30,14 +30,15 @@ class CheckLicenseTaskSpec extends Specification{
     File localBuildCacheDirectory
     File allowed
 
-    BuildResult result(String[] arguments){
+    BuildResult result(String[] arguments) {
         return GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(testProjectDir.getRoot())
             .withArguments(arguments)
             .build()
     }
-    BuildResult failResult(String[] arguments){
+
+    BuildResult failResult(String[] arguments) {
         return GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(testProjectDir.getRoot())
@@ -146,13 +147,13 @@ class CheckLicenseTaskSpec extends Specification{
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
 
         when:
-        buildResult = result( "--build-cache", "clean", "checkLicense")
+        buildResult = result("--build-cache", "clean", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
 
         when:
-        buildResult = result( "--build-cache", "checkLicense")
+        buildResult = result("--build-cache", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
@@ -209,7 +210,7 @@ class CheckLicenseTaskSpec extends Specification{
         """
 
         when:
-        BuildResult buildResult = failResult( "--build-cache", "checkLicense")
+        BuildResult buildResult = failResult("--build-cache", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FAILED
@@ -265,13 +266,13 @@ class CheckLicenseTaskSpec extends Specification{
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
 
         when:
-        buildResult = result( "--build-cache", "clean", "checkLicense")
+        buildResult = result("--build-cache", "clean", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
 
         when:
-        buildResult = result( "--build-cache", "checkLicense")
+        buildResult = result("--build-cache", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
@@ -352,7 +353,7 @@ class CheckLicenseTaskSpec extends Specification{
         }"""
 
         when:
-        BuildResult buildResult = failResult( "checkLicense")
+        BuildResult buildResult = failResult("checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FAILED
@@ -402,17 +403,18 @@ class CheckLicenseTaskSpec extends Specification{
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
 
         when:
-        buildResult = result( "--build-cache", "clean", "checkLicense")
+        buildResult = result("--build-cache", "clean", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
 
         when:
-        buildResult = result( "--build-cache", "checkLicense")
+        buildResult = result("--build-cache", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
     }
+
     def "it should fail when no allowedLicensesFile specified and pass when adding allowedLicensesFile"() {
         given:
         buildFile << """
@@ -484,7 +486,7 @@ class CheckLicenseTaskSpec extends Specification{
         }"""
 
         when:
-        BuildResult buildResult = result( "checkLicense")
+        BuildResult buildResult = result("checkLicense")
 
         then:
         thrown Exception
@@ -533,13 +535,13 @@ class CheckLicenseTaskSpec extends Specification{
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
 
         when:
-        buildResult = result( "--build-cache", "clean", "checkLicense")
+        buildResult = result("--build-cache", "clean", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
 
         when:
-        buildResult = result( "--build-cache", "checkLicense")
+        buildResult = result("--build-cache", "checkLicense")
 
         then:
         buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE


### PR DESCRIPTION
By running tests on Windows is problem with backslash in string representing file path and tests fail. The PR contains escaping characters in path string before inserting to the test `build.gradle`.