### PR TITLE
Fix imported module dependencies in license checker

### DIFF
--- a/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
@@ -28,7 +28,7 @@ class LicenseCheckerFileReader {
     static List<Dependency> importDependencies(File projectDependenciesFile) {
         def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(projectDependenciesFile)
         def allDependencies = slurpResult.dependencies.collect { new Dependency(it.moduleName, it.moduleVersion, it.moduleLicenses) }
-        allDependencies += slurpResult.importedModules.collect { new Dependency(it.dependencies) }
+        allDependencies += slurpResult.importedModules.collect { it.dependencies.collect { new Dependency(it) } }.flatten()
         return allDependencies
     }
 }

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -222,23 +222,27 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name1",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License1",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name1",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name2",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License2",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name2",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""
@@ -258,21 +262,25 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name1",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name1",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name2",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name2",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""
@@ -292,21 +300,25 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License1",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License1",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License2",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License2",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""
@@ -354,23 +366,27 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name3",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License3",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name3",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License3",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name4",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicense": "License4",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name4",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicense": "License4",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""
@@ -426,23 +442,27 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name3",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleLicense": "License3",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name3",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleLicense": "License3",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name4",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleLicense": "License4",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name4",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleLicense": "License4",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""
@@ -495,21 +515,25 @@ class LicenseCheckerFileReaderSpec extends Specification {
             "importedModules": [
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleUrl": "some-projectUrl",
-                        "moduleLicense": "License3",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleUrl": "some-projectUrl",
+                            "moduleLicense": "License3",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 },
                 {
                     "moduleName": "bundle1",
-                    "dependencies": {
-                        "moduleName": "Name5",
-                        "moduleUrl": "some-projectUrl",
-                        "moduleVersion": "some-version",
-                        "moduleLicenseUrl": "apache-url"
-                    }
+                    "dependencies": [
+                        {
+                            "moduleName": "Name5",
+                            "moduleUrl": "some-projectUrl",
+                            "moduleVersion": "some-version",
+                            "moduleLicenseUrl": "apache-url"
+                        }
+                    ]
                 }
             ]
         }"""


### PR DESCRIPTION
This fixes the handling of imported module dependencies, which are lists of dependencies not single objects. (#156)
The JSON reporter writes them out like:
```
    "importedModules": [
        {
            "moduleName": "external-module",
            "dependencies": [
                {
                    "moduleName": "some-module",
                    "moduleVersion": "1.0.0"
                }
            ]
        }
```

however this was expecting:

```
    "importedModules": [
        {
            "moduleName": "external-module",
            "dependencies": {
                  "moduleName": "some-module",
                  "moduleVersion": "1.0.0"
            }
        }
```