### PR TITLE
Fix deprecation warnings when running with Gradle 6.0

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -30,8 +30,11 @@ class LicenseReportExtension {
 
     public String outputDir
     public Project[] projects
+    @Nested
     public ReportRenderer[] renderers
+    @Nested
     public DependencyDataImporter[] importers
+    @Nested
     public DependencyFilter[] filters
     public String[] configurations
     public boolean excludeOwnGroup
@@ -74,13 +77,10 @@ class LicenseReportExtension {
         snapshot.join("!")
     }
 
-    @Nested
     private List<ReportRenderer> getRenderersCache() { return this.renderers }
 
-    @Nested
     private List<DependencyDataImporter> getImportersCache() { return this.importers }
 
-    @Nested
     private List<DependencyFilter> getFiltersCache() { return this.filters }
 
     void setRenderer(ReportRenderer renderer) {


### PR DESCRIPTION
Messages look like:

```
Property 'classpath' is declared without normalization specified. Properties of cacheable work must declare their normalization via @PathSensitive, @Classpath or @CompileClasspath. Defaulting to PathSensitivity.ABSOLUTE. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache' is private and annotated with @Nested. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.importersCache' is private and annotated with @Nested. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.licenseReportExtensionSnapshot' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderersCache' is private and annotated with @Nested. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderer' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache.$0.filterConfigForCache' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache.$0.bundleMap' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache.$0.config' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache.$0.duplicateFilter' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.filtersCache.$0.normalizerConfig' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderersCache.$0.fileNameCache' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderersCache.$1.fileNameCache' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderersCache.$2.fileNameCache' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
Property 'config.renderersCache.$2.onlyOneLicensePerModuleCahce' is private and annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0.
```

I'm not sure why there are `private` getter-methods but `public` properties, so I left the methods.