### PR TITLE
Add/Fix lingering Task property annotations

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -30,7 +30,8 @@ class LicenseReportExtension {
 
     public String outputDir
     public Project[] projects
-    public ReportRenderer[] renderers
+    @Nested
+    ReportRenderer[] renderers
     public DependencyDataImporter[] importers
     public DependencyFilter[] filters
     public String[] configurations
@@ -53,7 +54,7 @@ class LicenseReportExtension {
     }
 
     @Input
-    private String getLicenseReportExtensionSnapshot() {
+    String getLicenseReportExtensionSnapshot() {
         def snapshot = []
         snapshot << 'projects'
         snapshot += projects.collect { it.path }
@@ -81,6 +82,7 @@ class LicenseReportExtension {
         renderers = renderer
     }
 
+    @Nested
     ReportRenderer getRenderer() {
         if (renderers != null && renderers.size() > 0) {
             return renderers[0]

--- a/src/main/groovy/com/github/jk1/license/task/CacheableReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CacheableReportTask.groovy
@@ -18,12 +18,14 @@ package com.github.jk1.license.task
 import com.github.jk1.license.reader.ProjectReader
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
 
 @CacheableTask
 class CacheableReportTask extends ReportTask {
 
     @InputFiles
+    @Classpath
     FileCollection getClasspath() {
         getConfig().projects
             .collectMany { ProjectReader.findConfiguredConfigurations(it, getConfig()) }

--- a/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
@@ -22,7 +22,10 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
@@ -31,6 +34,7 @@ class CheckLicenseTask extends DefaultTask {
     final static String NOT_PASSED_DEPENDENCIES_FILE = "dependencies-without-allowed-license.json"
 
     private Logger LOGGER = Logging.getLogger(CheckLicenseTask.class)
+    @Nested
     LicenseReportExtension config = getProject().licenseReport
 
     CheckLicenseTask() {
@@ -39,11 +43,13 @@ class CheckLicenseTask extends DefaultTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     File getAllowedLicenseFile() {
         return config.allowedLicensesFile
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     File getProjectDependenciesData() {
         return new File("${config.outputDir}/${PROJECT_JSON_FOR_LICENSE_CHECKING_FILE}")
     }


### PR DESCRIPTION
# What does this PR do?

* Add/Fix lingering Task property annotations that are causing build issues
  * `CacheableReportTask.groovy`
    * Apply the `@ClassPath` normalization strategy to the `classpath` task property
  * `CheckLicenseTask.groovy`
    * Declare `config` as a `@Nested` task property
    * Apply the `ABSOLUTE`  path sensitivity to `allowedLicenseFile` task property
    * Apply the `ABSOLUTE`  path sensitivity to `projectDependenciesData` task property
  * `LicenseReportExtension.groovy`
    * Apply annotations to properties that tasks use transitively
      * Declare `renderers` as a `@Nested` task property
      * Remove `renderers` explicit `public` visibility modifier to make the validator happy
      * Declare `renderer` as a `@Nested` task property
      * Increase the visibility of the `licenseReportExtensionSnapshot` task property to `public` (from `private`) to leverage the existing `@Input` annotation

# Why was this PR opened?

The build is currently failing due to the `validatePlugins` task failing. Some changes were made in #159 to resolve Gradle 6.0 deprecations, which resulted in the resolution of #162, but it looks like there were a handful of lingering issues with task annotations after the integration of those changes. This PR fixes the remaining issues that are causing the build to fail

# Are there changes in the PR that require closer review?
* `LicenseReportExtension.groovy`
  *  Should the visibility of `licenseReportExtensionSnapshot` been increased, or annotation removed? I couldn't find any usage of it.
* `CheckLicenseTask.groovy`
  * Is `ABSOLUTE`  path sensitivity ok for the `allowedLicenseFile` and `projectDependenciesData` task properties?

# Does this PR meet the usual acceptance criteria?
- [x] Project Builds 
- [x] Tests pass
- [x] Document generates successfully with no errors or warnings

# Related Issues / PRs
* #159 
* #162 