### PR TITLE
Add support for remote allowedLicenses file

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -39,6 +39,7 @@ class LicenseReportExtension {
     public String[] excludeGroups
     public String[] excludes
     public File allowedLicensesFile
+    public URL allowedLicensesUrl
 
     LicenseReportExtension(Project project) {
         outputDir = "${project.buildDir}/reports/dependency-license"

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -38,8 +38,7 @@ class LicenseReportExtension {
     public boolean excludeOwnGroup
     public String[] excludeGroups
     public String[] excludes
-    public File allowedLicensesFile
-    public URL allowedLicensesUrl
+    public Object allowedLicensesFile
 
     LicenseReportExtension(Project project) {
         outputDir = "${project.buildDir}/reports/dependency-license"

--- a/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
@@ -21,12 +21,9 @@ import org.gradle.api.GradleException
 class LicenseChecker {
 
     void checkAllDependencyLicensesAreAllowed(
-        File allowedLicensesFile, URL allowedLicensesUrl, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
+        Object allowedLicensesFile, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
         List<Dependency> allDependencies = LicenseCheckerFileReader.importDependencies(projectLicensesDataFile)
-        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile.toURI().toURL())
-        if(allowedLicensesUrl != null) {
-            allowedLicenses.addAll(LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesUrl))
-        }
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile)
         List<Dependency> notPassedDependencies = searchForNotAllowedDependencies(allDependencies, allowedLicenses)
         generateNotPassedDependenciesFile(notPassedDependencies, notPassedDependenciesOutputFile)
 

--- a/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
@@ -23,7 +23,7 @@ class LicenseChecker {
     void checkAllDependencyLicensesAreAllowed(
         File allowedLicensesFile, URL allowedLicensesUrl, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
         List<Dependency> allDependencies = LicenseCheckerFileReader.importDependencies(projectLicensesDataFile)
-        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile)
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile.toURI().toURL())
         if(allowedLicensesUrl != null) {
             allowedLicenses.addAll(LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesUrl))
         }

--- a/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
@@ -21,9 +21,12 @@ import org.gradle.api.GradleException
 class LicenseChecker {
 
     void checkAllDependencyLicensesAreAllowed(
-        File allowedLicensesFile, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
+        File allowedLicensesFile, URL allowedLicensesUrl, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
         List<Dependency> allDependencies = LicenseCheckerFileReader.importDependencies(projectLicensesDataFile)
         List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile)
+        if(allowedLicensesUrl != null) {
+            allowedLicenses.addAll(LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesUrl))
+        }
         List<Dependency> notPassedDependencies = searchForNotAllowedDependencies(allDependencies, allowedLicenses)
         generateNotPassedDependenciesFile(notPassedDependencies, notPassedDependenciesOutputFile)
 

--- a/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
@@ -20,11 +20,6 @@ import groovy.json.JsonSlurper
 
 class LicenseCheckerFileReader {
 
-    static List<AllowedLicense> importAllowedLicenses(File allowedLicensesFile) {
-        def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(allowedLicensesFile)
-        return slurpResult.allowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }
-    }
-
     static List<AllowedLicense> importAllowedLicenses(URL allowedLicensesUrl) {
         def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(allowedLicensesUrl)
         return slurpResult.allowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }

--- a/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseCheckerFileReader.groovy
@@ -25,6 +25,11 @@ class LicenseCheckerFileReader {
         return slurpResult.allowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }
     }
 
+    static List<AllowedLicense> importAllowedLicenses(URL allowedLicensesUrl) {
+        def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(allowedLicensesUrl)
+        return slurpResult.allowedLicenses.collect { new AllowedLicense(it.moduleName, it.moduleVersion, it.moduleLicense) }
+    }
+
     static List<Dependency> importDependencies(File projectDependenciesFile) {
         def slurpResult = new JsonSlurper().setType(JsonParserType.LAX).parse(projectDependenciesFile)
         def allDependencies = slurpResult.dependencies.collect { new Dependency(it.moduleName, it.moduleVersion, it.moduleLicenses) }

--- a/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
@@ -21,7 +21,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.TaskAction
@@ -47,6 +49,12 @@ class CheckLicenseTask extends DefaultTask {
         return config.allowedLicensesFile
     }
 
+    @Input
+    @Optional
+    URL getAllowedLicenseUrl() {
+        return config.allowedLicensesUrl
+    }
+
     @InputFile
     @PathSensitive(PathSensitivity.NAME_ONLY)
     File getProjectDependenciesData() {
@@ -64,6 +72,6 @@ class CheckLicenseTask extends DefaultTask {
         LicenseChecker licenseChecker = new LicenseChecker()
         LOGGER.info("Check licenses if they are allowed to use.")
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            getAllowedLicenseFile(), getProjectDependenciesData(), notPassedDependenciesFile)
+            getAllowedLicenseFile(), getAllowedLicenseUrl(), getProjectDependenciesData(), notPassedDependenciesFile)
     }
 }

--- a/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.TaskAction
@@ -43,16 +42,9 @@ class CheckLicenseTask extends DefaultTask {
         description = 'Check if License could be used'
     }
 
-    @InputFile
-    @PathSensitive(PathSensitivity.NAME_ONLY)
-    File getAllowedLicenseFile() {
-        return config.allowedLicensesFile
-    }
-
     @Input
-    @Optional
-    URL getAllowedLicenseUrl() {
-        return config.allowedLicensesUrl
+    Object getAllowedLicenseFile() {
+        return config.allowedLicensesFile
     }
 
     @InputFile
@@ -72,6 +64,6 @@ class CheckLicenseTask extends DefaultTask {
         LicenseChecker licenseChecker = new LicenseChecker()
         LOGGER.info("Check licenses if they are allowed to use.")
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            getAllowedLicenseFile(), getAllowedLicenseUrl(), getProjectDependenciesData(), notPassedDependenciesFile)
+            getAllowedLicenseFile(), getProjectDependenciesData(), notPassedDependenciesFile)
     }
 }

--- a/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/CheckLicenseTaskSpec.groovy
@@ -550,12 +550,6 @@ class CheckLicenseTaskSpec extends Specification {
 
     def "it should pass when only containing included licenses which are referenced by url"() {
         given:
-        File emptyAllowed = testProjectDir.newFile('empty-allowed-licenses.json') << """
-        {
-            "allowedLicenses":[
-            ]
-        }"""
-
         buildFile << """
             import com.github.jk1.license.filter.*
 
@@ -588,8 +582,70 @@ class CheckLicenseTaskSpec extends Specification {
             }
             licenseReport {
                 filters = new LicenseBundleNormalizer()
-                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(emptyAllowed.path)}")
-                allowedLicensesUrl = new File("${StringEscapeUtils.escapeJava(allowed.path)}").toURI().toURL()
+                allowedLicensesFile = new File("${StringEscapeUtils.escapeJava(allowed.path)}").toURI().toURL()
+            }
+        """
+
+        when:
+        BuildResult buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.SUCCESS
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        buildResult = result("--build-cache", "clean", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        buildResult = result("--build-cache", "checkLicense")
+
+        then:
+        buildResult.task(":checkLicense").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "it should pass when only containing included licenses which are referenced by file name"() {
+        given:
+        buildFile << """
+            import com.github.jk1.license.filter.*
+
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+                id 'com.github.jk1.dependency-license-report' version '1.2'
+            }
+
+            apply plugin: 'java'
+
+            group 'greeting'
+            version '0.0.1'
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
+                compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
+                compile "org.jetbrains.kotlin:kotlin-reflect"
+                compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+            }
+
+            compileKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            compileTestKotlin {
+                kotlinOptions.jvmTarget = "1.8"
+            }
+            licenseReport {
+                filters = new LicenseBundleNormalizer()
+                allowedLicensesFile = "${StringEscapeUtils.escapeJava(allowed.path)}"
             }
         """
 

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -573,4 +573,13 @@ class LicenseCheckerFileReaderSpec extends Specification {
         allowedLicenses.collect { it.moduleLicense } == ["License1", "License2", "License3"]
         allowedLicenses.collect { it.moduleName } == [null,  null, null]
     }
+
+    def "it reads out all the allowed licenses from a file reference by string"() {
+        when:
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile.path)
+
+        then:
+        allowedLicenses.collect { it.moduleLicense } == ["License1", "License2", "License3"]
+        allowedLicenses.collect { it.moduleName } == [null,  null, null]
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -51,7 +51,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
 
     def "it reads out all the allowed licenses"() {
         when:
-        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseUrl)
 
         then:
         allowedLicenses.collect { it.moduleLicense } == ["License1", "License2", "License3"]
@@ -63,7 +63,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
         allowedLicenseFile.text = """{"allowedLicenses":[]}"""
 
         when:
-        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseUrl)
 
         then:
         allowedLicenses == []
@@ -87,7 +87,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
         }"""
 
         when:
-        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseFile)
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseUrl)
 
         then:
         allowedLicenses.moduleLicense == [null, null, null]

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -24,6 +24,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
     File allowedLicenseFile
+    URL allowedLicenseUrl
     File projectDataFile
 
     def setup() {
@@ -45,6 +46,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
                 }
             ]
         }"""
+        allowedLicenseUrl =  allowedLicenseFile.toURI().toURL()
     }
 
     def "it reads out all the allowed licenses"() {
@@ -561,5 +563,14 @@ class LicenseCheckerFileReaderSpec extends Specification {
 
         then:
         dependencies == []
+    }
+
+    def "it reads out all the allowed licenses from an url"() {
+        when:
+        List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicenseUrl)
+
+        then:
+        allowedLicenses.collect { it.moduleLicense } == ["License1", "License2", "License3"]
+        allowedLicenses.collect { it.moduleName } == [null,  null, null]
     }
 }

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
@@ -27,6 +27,7 @@ class LicenseCheckerSpec extends Specification {
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
     File allowedLicenseFile
+    URL allowedLicenseUrl
     File projectDataFile
     File notPassedDependenciesFile
 
@@ -47,38 +48,38 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1", 
-                    "moduleName": "org.jetbrains", 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1",
+                    "moduleName": "org.jetbrains",
                 },
-                { 
-                    "moduleLicense": "Apache Software License, 
-                    Version 1.1", "moduleName": "org.jetbrains.*" 
+                {
+                    "moduleLicense": "Apache Software License,
+                    Version 1.1", "moduleName": "org.jetbrains.*"
                 },
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1", 
-                    "moduleName": "org.jetbrains" 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1",
+                    "moduleName": "org.jetbrains"
                 },
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1" 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1"
                 },
-                { 
-                    "moduleLicense": "Apache License, Version 2.0" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0"
                 },
-                { 
-                    "moduleLicense": "The 2-Clause BSD License" 
+                {
+                    "moduleLicense": "The 2-Clause BSD License"
                 },
-                { 
-                    "moduleLicense": "The 3-Clause BSD License" 
+                {
+                    "moduleLicense": "The 3-Clause BSD License"
                 },
-                { 
-                    "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0" 
+                {
+                    "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL), Version 1.0"
                 },
-                { 
-                    "moduleLicense": "MIT License" 
+                {
+                    "moduleLicense": "MIT License"
                 },
-                { 
-                    "moduleLicense": ".*", "moduleName": "org.jetbrains" 
+                {
+                    "moduleLicense": ".*", "moduleName": "org.jetbrains"
                 }
             ]
         }"""
@@ -95,31 +96,31 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1" 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1"
                 },
-                { 
-                    "moduleLicense": "MIT License" 
+                {
+                    "moduleLicense": "MIT License"
                 }
             ]
         }"""
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache Software License, Version 1.1"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -128,7 +129,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -139,23 +140,23 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1" 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1"
                 },
-                { 
-                    "moduleLicense": "MIT License" 
+                {
+                    "moduleLicense": "MIT License"
                 }
             ]
         }"""
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "some-other-license"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -164,7 +165,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
 
@@ -179,8 +180,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleName": ".*mod1" 
+                {
+                    "moduleName": ".*mod1"
                 }
             ]
         }"""
@@ -188,7 +189,7 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "some-other-license"
@@ -201,7 +202,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -219,12 +220,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 }
             ]
@@ -233,7 +234,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -247,8 +248,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleName": "dummy-group:.*" 
+                {
+                    "moduleName": "dummy-group:.*"
                 }
             ]
         }"""
@@ -256,52 +257,52 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod3"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod4"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                         "moduleName": "dummy-group:mod5"
                 },
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod6"
                 }
             ]
@@ -310,7 +311,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -321,8 +322,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache Software License, Version 1.1", "moduleName": "mod1" 
+                {
+                    "moduleLicense": "Apache Software License, Version 1.1", "moduleName": "mod1"
                 }
             ]
         }"""
@@ -330,12 +331,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 }
             ]
@@ -344,7 +345,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -358,8 +359,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "1.0" 
+                {
+                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "1.0"
                 }
             ]
         }"""
@@ -367,12 +368,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2",
                     "moduleVersion": "1.0"
                 }
@@ -382,7 +383,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -393,8 +394,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "2.0" 
+                {
+                    "moduleLicense": "MIT License", "moduleName": ".*mod2", "moduleVersion": "2.0"
                 }
             ]
         }"""
@@ -402,12 +403,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2",
                     "moduleVersion": "1.0"
                 }
@@ -417,7 +418,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -432,7 +433,7 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
+                {
                     "moduleLicense": "MIT License", "moduleName": ".*mod2"
                 }
             ]
@@ -441,12 +442,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "MIT License"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2",
                     "moduleVersion": "1.0"
                 }
@@ -456,7 +457,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -467,8 +468,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -476,7 +477,7 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -485,7 +486,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
 
         then:
@@ -497,9 +498,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": ".*", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": ".*",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -507,7 +508,7 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -516,7 +517,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
 
         then:
@@ -528,9 +529,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "mod1"
                 }
             ]
         }"""
@@ -538,12 +539,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 }
             ]
@@ -552,7 +553,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -565,9 +566,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", 
-                    "moduleName": ".*mod1" 
+                {
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3",
+                    "moduleName": ".*mod1"
                 }
             ]
         }"""
@@ -575,12 +576,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -589,7 +590,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -600,21 +601,21 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", 
-                    "moduleName": "some-other-groups" 
+                {
+                    "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3",
+                    "moduleName": "some-other-groups"
                 }
             ]
         }"""
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -623,7 +624,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -637,8 +638,8 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleName": "some-other-groups:mod1" 
+                {
+                    "moduleName": "some-other-groups:mod1"
                 }
             ]
         }"""
@@ -646,12 +647,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "GNU LESSER GENERAL PUBLIC LICENSE, Version 3"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -660,7 +661,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -674,9 +675,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -684,12 +685,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -698,7 +699,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -709,9 +710,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -719,12 +720,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "some-other-license"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -733,7 +734,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -747,9 +748,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -757,12 +758,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod2"
                 }
             ]
@@ -771,7 +772,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -791,12 +792,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -805,7 +806,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -819,9 +820,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -829,7 +830,7 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {
                             "moduleLicense": "License1"
@@ -840,7 +841,7 @@ class LicenseCheckerSpec extends Specification {
                         {
                             "moduleLicense": "Apache License, Version 2.0"
                         }
-                    ], 
+                    ],
                     "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -849,7 +850,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -860,9 +861,9 @@ class LicenseCheckerSpec extends Specification {
         allowedLicenseFile << """
         {
             "allowedLicenses":[
-                { 
-                    "moduleLicense": "Apache License, Version 2.0", 
-                    "moduleName": "dummy-group:mod1" 
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleName": "dummy-group:mod1"
                 }
             ]
         }"""
@@ -870,12 +871,12 @@ class LicenseCheckerSpec extends Specification {
         projectDataFile << """
         {
             "dependencies":[
-                { 
+                {
                     "moduleLicenses": [
                         {"moduleLicense": "License1"},
                         {"moduleLicense": "License2"},
                         {"moduleLicense": "License3"}
-                    ], 
+                    ],
                 "moduleName": "dummy-group:mod1"
                 }
             ]
@@ -884,7 +885,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
@@ -27,7 +27,6 @@ class LicenseCheckerSpec extends Specification {
     TemporaryFolder testProjectDir = new TemporaryFolder()
 
     File allowedLicenseFile
-    URL allowedLicenseUrl
     File projectDataFile
     File notPassedDependenciesFile
 
@@ -129,7 +128,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -165,7 +164,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
 
@@ -202,7 +201,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -234,7 +233,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -311,7 +310,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -345,7 +344,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -383,7 +382,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -418,7 +417,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -457,7 +456,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -486,7 +485,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
 
         then:
@@ -517,7 +516,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
 
         then:
@@ -553,7 +552,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -590,7 +589,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -624,7 +623,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -661,7 +660,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -699,7 +698,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -734,7 +733,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -772,7 +771,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -806,7 +805,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -850,7 +849,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -885,7 +884,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, allowedLicenseUrl, projectDataFile, notPassedDependenciesFile)
+            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)


### PR DESCRIPTION
Belongs to https://github.com/jk1/Gradle-License-Report/issues/173 .

Adds an optional parameter for specifying a URL for the allowed license file.
The local file still must be present.

The allowed licenses from both sources (if present) are merged into the list of allowed licenses. 

What do you think?