### PR TITLE
MIT LicenseNamePattern Update

### DIFF
--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -84,7 +84,7 @@
     { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/LGPL-3\\.0" },
     { "bundleName" : "LGPL-3.0-only", "licenseNamePattern" : "lgplv?3" },
     { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?gnu\\.org/licenses(/old-licenses)?/lgpl(-3)?(\\.(html|txt))?" },
-    { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\slicen[c|s]e)?" },
+    { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\slicen[c|s]e)?(\\s\\(MIT\\))?" },
     { "bundleName" : "MIT", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/MIT(\\.php)?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.).opensource\\.org/licenses/MPL-2\\.0" },


### PR DESCRIPTION
Ran into some MIT licenses with the name: "The MIT License (MIT)", updating the regex to optionally grab the "(MIT)"