### PR TITLE
1.14.1 extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **/.idea
 **/.gradle
 **/build
+**/bin
+**/.classpath
+**/.project
+**/.settings/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'idea'
+	id 'eclipse'
     id 'groovy'
     id 'maven-publish'
     id 'java-gradle-plugin'
@@ -9,7 +10,7 @@ plugins {
 }
 
 group = "com.github.jk1"
-version = "1.14"
+version = "1.14.1"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -66,7 +66,8 @@ class LicenseFilesReader {
                 "readme",
                 "notice",
                 "copying",
-                "copying.lesser"
+                "copying.lesser",
+                "about"
         ]
         Set<ZipEntry> entryNames = zipFile.entries().toList().findAll { ZipEntry entry ->
             String name = entry.getName()
@@ -104,6 +105,10 @@ class LicenseFilesReader {
         String moduleLicenseUrl = null
 
         def text = new File(config.outputDir, file).text
+        if (text.contains('Eclipse\n\t\tPublic License Version 2.0')) {
+            moduleLicense = 'Eclipse Public License Version 2.0'
+            moduleLicenseUrl = 'http://www.eclipse.org/legal/epl-2.0'
+        }
         if (text.contains('Apache License, Version 2.0')) {
             moduleLicense = 'Apache License, Version 2.0'
             moduleLicenseUrl = 'https://www.apache.org/licenses/LICENSE-2.0'

--- a/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
@@ -93,7 +93,14 @@ class ManifestReader {
         data.vendor = attr.getValue('Bundle-Vendor') ?: attr.getValue('Implementation-Vendor')
         data.url = attr.getValue('Bundle-DocURL')
         if (Files.maybeLicenseUrl(bundleLicense)) {
-            data.licenseUrl = bundleLicense
+			def allLicenseParts = bundleLicense.split(';')
+            data.licenseUrl = allLicenseParts[0]
+			allLicenseParts.each { 
+				def additionalParameter = it.split('=')
+				
+				if (additionalParameter[0] == 'description')
+					data.license = additionalParameter[1]
+			}
         }
         else {
             data.license = bundleLicense


### PR DESCRIPTION
When using your gradle plugin to generate license report for all our applications i noticed, that not all use cases found were supported. I therefore addedthe following 2 extensions:

1. I have extended the extraction of the license from Bundle-License manifest header which can also contain the license url and the license name in the form "Bundle-License: license-url;description=license-name"

2. Also i have added the about.html file normally added to libraries from Eclipse Foundation to the LicenseFilesReader and and extended the createFileDetails method to extract the Eclipse Public License Version 2.0 from the about.html file.