### PR TITLE
Exclude boms from the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ licenseReport {
     // Don't include artifacts of project's own group into the report
     excludeOwnGroup = true
 
+    // Don't exclude bom dependencies.
+    // If set to true, then all boms will be excluded from the report
+    excludeBoms = false
+
     // Set custom report renderer, implementing ReportRenderer.
     // Yes, you can write your own to support any format necessary.
     renderers = [new XmlReportRenderer('third-party-libs.xml', 'Back-End Libraries')]
@@ -309,7 +313,7 @@ import com.github.jk1.license.ImportedModuleBundle;
 import com.github.jk1.license.importer.DependencyDataImporter;
 import java.util.Collection;
 
-public class CustomImporter implements DependencyDataImporter{
+public class CustomImporter implements DependencyDataImporter {
 
     public String getImporterName() {
         return "Custom importer";
@@ -358,7 +362,7 @@ The same technique can be used to create a filter or a renderer to support custo
 
 This task is for checking dependencies/imported modules if their licenses are allowed to be used.
 
-```batch
+```shell
 ./gradlew checkLicense
 ```
 
@@ -430,4 +434,3 @@ licenseReport {
     allowedLicensesFile = new URL("http://company.com/licenses/allowed-licenses.json")
 }
 ```
-

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation localGroovy()
 
     testImplementation gradleTestKit()
-    testImplementation("org.spockframework:spock-core:1.0-groovy-2.4") {
+    testImplementation("org.spockframework:spock-core:1.3-groovy-2.4") {
         exclude group: 'org.codehaus.groovy'
     }
 }

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.tasks.Nested
 
 class LicenseReportExtension {
 
-    // todo: delete unused
     public static final String[] ALL = []
 
     public String outputDir

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderFuncSpec.groovy
@@ -31,7 +31,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
             }
             repositories {
                 mavenCentral()
-                maven { url "https://dl.bintray.com/realm/maven" }
+                maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local" }
                 maven { url "https://maven.repository.redhat.com/ga" }
             }
 
@@ -96,7 +96,7 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
     }
 
 
-    static final def DEPENDENCY_REALM_ANDROID = "io.realm:realm-android:0.82.2"
+    static final def DEPENDENCY_REALM_ANDROID = "io.realm:realm-android:0.82.2-SNAPSHOT"
     static final def EXPECTED_ARTIFACT_MISMATCH_REALM_ANDROID = "Artifact: io.realm:realm-android / Pom: com.squareup:javawriter)"
     static final def EXPECTED_CONTENT_REALM_ANDROID = """[
     {
@@ -152,7 +152,8 @@ class ProjectReaderFuncSpec extends AbstractGradleRunnerFunctionalSpec {
 ]"""
 
     @Unroll
-    def "it reads the correct project url for #dependency"(String dependency, String expectedContent,
+    def "it reads the correct project url for #dependency"(String dependency,
+                                                           String expectedContent,
                                                            String expectedMismatchMessage) {
         buildFile << """
             dependencies {


### PR DESCRIPTION
This pull request suggests a solution for the problem with bom license resolution that is described in multiple issues:

- https://github.com/jk1/Gradle-License-Report/issues/180
- https://github.com/jk1/Gradle-License-Report/issues/201
- https://github.com/jk1/Gradle-License-Report/issues/207

The root cause seems to be that more and more projects are adding extended [gradle metadata](https://blog.gradle.org/alignment-with-gradle-module-metadata). It causes boms to appear in the dependency graph, used for version alignment. A little bit more information is available in the comment [here](https://github.com/jk1/Gradle-License-Report/issues/180#issuecomment-828832627). 

There is a quick fix for this problem - manually exclude boms from the report (using `excludes` property). It's fine to exclude bom files from the report because they would have the same license as dependencies that they are managing, so the license will be indirectly checked anyways. While this approach works it might be complicated in bigger projects with many dependencies. Boms appear in the dependency graph without being explicitly added, just after version update of some used dependencies.

The other approach would be to use filters to filter out all boms in the project. This would require users to implement such a filter, have a solution in place to share it between multiple projects, and will make the overall setup more complex.

The proposed solution uses the same idea (exclude all boms from the report), but implements it natively in the plugin. The behavior is controlled by a single boolean flag.

**Not in the scope:**
The proposed solution doesn't try to improve the way filtering is done internally. It uses the same approach as other filters. It makes code more consistent and minimizes the scope of changes.