### PR TITLE
Partial fix for sub-project configurations in ExcludeTransitiveDependenciesFilter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.github.jk1"
-version = "1.17"
+version = "1.17-WD"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.Project
 @Canonical
 class ProjectData {
     Project project
+    Project[] projects
     Set<ConfigurationData> configurations = new TreeSet<ConfigurationData>()
     List<ImportedModuleBundle> importedModules = new ArrayList<ImportedModuleBundle>()
     Set<ModuleData> getAllDependencies() {

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -38,6 +38,7 @@ class ProjectReader {
     ProjectData read(Project project) {
         ProjectData data = new ProjectData()
         data.project = project
+        data.projects = config.projects
 
         Project[] projectsToScan = config.projects
         LOGGER.info("Configured projects: ${projectsToScan.join(',')}")


### PR DESCRIPTION
Updates the ExcludeTransitiveDependenciesFilter so that it can find
configurations correctly by searching the project tree rather than
just looking at the root project.
Note this is a partial fix and assumes that the configuration(s)
specified in the plugin config are unique across sub-projects.
The more complete fix would be to merge configurations with the
same name (see ProjectData.groovy).