### PR TITLE
:wrench: set sources Compatibility to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ plugins {
 group = "com.github.jk1"
 version = "2.0"
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
For multi-module projects, the gradle 7+ ready version was raising ambigus variant selection for modules resolutions.

Thanks to this thread : https://github.com/gradle/gradle/issues/12126 I was able to understand the issue was with a wrong sourceCompability attribute set in the jk1 plugin.

It was indeed still declaring

sourceCompatibility = 1.8
targetCompatibility = 1.8

instead of

sourceCompatibility = JavaVersion.VERSION_11
targetCompatibility = JavaVersion.VERSION_11

though it was declared to be "gradle 7+ ready".

Changing to JavaVersion.VERSION_11 and building the plugin in local solved the issue from my end.