### PR TITLE
Fix for failing externally imported licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Gradle License Report
+
 =====================
 
 [![Build Status](https://travis-ci.org/jk1/Gradle-License-Report.svg?branch=master)](https://travis-ci.org/jk1/Gradle-License-Report)

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerFileReaderSpec.groovy
@@ -260,6 +260,22 @@ class LicenseCheckerFileReaderSpec extends Specification {
 
         projectDataFile.text = """
         {
+        "dependencies": [
+            {
+                "moduleName": "Name1",
+                "moduleVersion": "some-version",
+                "moduleUrls": [
+                    "some-url"
+                ]
+            },
+            {
+                "moduleName": "Name2",
+                "moduleVersion": "some-version",
+                "moduleUrls": [
+                    "some-projectUrl"
+                ]           
+            }       
+            ],         
             "importedModules": [
                 {
                     "moduleName": "bundle1",
@@ -268,6 +284,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
                             "moduleName": "Name1",
                             "moduleUrl": "some-projectUrl",
                             "moduleVersion": "some-version",
+                            "moduleLicense": "some-license",
                             "moduleLicenseUrl": "apache-url"
                         }
                     ]
@@ -279,6 +296,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
                             "moduleName": "Name2",
                             "moduleUrl": "some-projectUrl",
                             "moduleVersion": "some-version",
+                            "moduleLicense": "some-license",
                             "moduleLicenseUrl": "apache-url"
                         }
                     ]
@@ -291,7 +309,7 @@ class LicenseCheckerFileReaderSpec extends Specification {
 
         then:
         dependencies.moduleName == ["Name1", "Name2"]
-        dependencies.moduleLicenses.moduleLicense == [[null], [null]]
+        dependencies.moduleLicenses.moduleLicense == [["some-license"], ["some-license"]]
     }
 
     def "read projectData importedModules moduleLicense"() {


### PR DESCRIPTION
Updated the existing dependencies having empty licenses for which the licenses were provided in imported modules.
This will fix the error which was reported at the time of report generation.