### PR TITLE
Fix title formatting

### DIFF
--- a/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
@@ -45,8 +45,8 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
 
     private void printDependencies(Map<String, List<ModuleData>> inventory, Map<String, Map<String, List<ImportedModuleData>>> externalInventories) {
         output << "\n"
-        output << "#${name}\n"
-        output << "##Dependency License Report\n"
+        output << "# ${name}\n"
+        output << "## Dependency License Report\n"
         output << "_${new Date().format('yyyy-MM-dd HH:mm:ss z')}_\n"
 
         inventory.keySet().sort().each { String license ->


### PR DESCRIPTION
The markdown renderer has a couple of bugs where it won't render the first two titles correctly.

Gist of this fix is:
```
#BAD TITLE
# GOOD TITLE
```