### PR TITLE
Exclude BOMs called "bom"

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -94,7 +94,9 @@ class LicenseReportExtension {
     }
 
     private boolean shouldExcludeBom(ResolvedDependency module) {
-        excludeBoms && module.getModuleName().endsWith("-bom") && module.getModuleArtifacts().isEmpty()
+        excludeBoms &&
+            (module.getModuleName().endsWith("-bom") || module.getModuleName() == "bom") &&
+            module.getModuleArtifacts().isEmpty()
     }
 
     private boolean shouldExcludeArtifact(ResolvedDependency module) {

--- a/src/test/groovy/com/github/jk1/license/reader/ExcludesFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ExcludesFuncSpec.groovy
@@ -62,6 +62,7 @@ class ExcludesFuncSpec extends AbstractGradleRunnerFunctionalSpec {
         buildFile << generateBuildWith(
             """
                 implementation platform("com.fasterxml.jackson:jackson-bom:2.12.3")
+                implementation platform("software.amazon.awssdk:bom:2.17.181")
                 implementation "javax.activation:activation:1.1.1"
             """.trim(),
             """excludeBoms = true"""


### PR DESCRIPTION
The AWS SDK uses a BOM whose module name is just `bom`, no prefix. Update the
BOM exclusion code to filter it out.
