### PR TITLE
fix: improve the license mapping for Apache 2.x

### DIFF
--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -44,7 +44,7 @@
     { "bundleName" : "0BSD", "licenseNamePattern" : "BSD[ |-]clause.*" },
     { "bundleName" : "0BSD", "licenseNamePattern" : "BSD[ |-]license.*" },
     { "bundleName" : "Apache-2.0", "licenseNamePattern" : ".*The Apache Software License, Version 2\\.0.*" },
-    { "bundleName" : "Apache-2.0", "licenseNamePattern" : "Apache[ |-|_]2.*" },
+    { "bundleName" : "Apache-2.0", "licenseNamePattern" : ".*?Apache[ |_-]2.*" },
     { "bundleName" : "Apache-2.0", "licenseNamePattern" : "ASL 2\\.0" },
     { "bundleName" : "Apache-2.0", "licenseNamePattern" : ".*Apache License,?( Version)? 2.*" },
     { "bundleName" : "Apache-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/Apache-2\\.0.*" },


### PR DESCRIPTION
1. The previous regex cannot match the license of Gson, which is `"Apache-2.0";link="https://www.apache.org/licenses/LICEN
 SE-2.0.txt"`. Below is the full content of the `MANIFEST.MF` of Gson 2.9.0.
2. More importantly, the previous regex is not valid because `-` should be at the last if we want to match the dash symbol.

```
Manifest-Version: 1.0
Created-By: 11.0.12 (Azul Systems, Inc.)
Build-Jdk-Spec: 11
Bnd-LastModified: 1644606872024
Bundle-ContactAddress: https://github.com/google/gson
Bundle-Description: Gson JSON library
Bundle-DocURL: https://github.com/google/gson/gson
Bundle-License: "Apache-2.0";link="https://www.apache.org/licenses/LICEN
 SE-2.0.txt"
Bundle-ManifestVersion: 2
Bundle-Name: Gson
Bundle-RequiredExecutionEnvironment: JavaSE-1.7, JavaSE-1.8
Bundle-SCM: url="https://github.com/google/gson/gson/",connection="scm:g
 it:https://github.com/google/gson.git/gson",developer-connection="scm:g
 it:git@github.com:google/gson.git/gson",tag="gson-parent-2.9.0"
Bundle-SymbolicName: com.google.gson
Bundle-Vendor: Google Gson Project
Bundle-Version: 2.9.0
Export-Package: com.google.gson;uses:="com.google.gson.reflect,com.googl
 e.gson.stream";version="2.9.0",com.google.gson.annotations;version="2.9
 .0",com.google.gson.reflect;version="2.9.0",com.google.gson.stream;vers
 ion="2.9.0"
Import-Package: sun.misc;resolution:=optional,com.google.gson.annotation
 s
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
Tool: Bnd-6.1.0.202111221555
Multi-Release: true
```
