### PR TITLE
Allow creating multiple tasks

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportPlugin.groovy
@@ -32,12 +32,13 @@ class LicenseReportPlugin implements Plugin<Project> {
     void apply(Project project) {
         assertCompatibleGradleVersion()
 
-        project.extensions.create('licenseReport', LicenseReportExtension, project)
+        def extension = project.extensions.create('licenseReport', LicenseReportExtension, project)
 
         def preparationTask = project.tasks.register("checkLicensePreparation", CheckLicensePreparationTask)
         def taskClass = project.getPlugins().hasPlugin('com.android.application') ? ReportTask : CacheableReportTask
         def generateLicenseReportTask = project.tasks.register('generateLicenseReport', taskClass) {
             it.shouldRunAfter(preparationTask)
+            it.config = extension
         }
         project.tasks.register('checkLicense', CheckLicenseTask) {
             it.dependsOn(preparationTask, generateLicenseReportTask)

--- a/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
@@ -33,13 +33,11 @@ class ReportTask extends DefaultTask {
     }
 
     @Nested
-    LicenseReportExtension getConfig() {
-        return getProject().licenseReport
-    }
+    LicenseReportExtension config
 
     @OutputDirectory
     File getOutputFolder() {
-        return new File(getConfig().outputDir)
+        return new File(config.outputDir)
     }
 
     @TaskAction


### PR DESCRIPTION
Making `config` a property of ReportTask is now possible to create multiple tasks with different configurations