### PR TITLE
Support scanning of buildScripts / used gradle plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ licenseReport {
     // Defaults to current project and all its subprojects
     projects = [project] + project.subprojects
 
+    // Select projects to examine their buildScripts / plugins for dependencies.
+    // Defaults to nothing. Could be configured like [project] + project.subprojects
+    buildScriptProjects = []
+
     // Adjust the configurations to fetch dependencies. Default is 'runtimeClasspath'
     // For Android projects use 'releaseRuntimeClasspath' or 'yourFlavorNameReleaseRuntimeClasspath'
     // Use 'ALL' to dynamically resolve all configurations:

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -21,6 +21,7 @@ import com.github.jk1.license.render.ReportRenderer
 import com.github.jk1.license.render.SimpleHtmlReportRenderer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
 
@@ -31,6 +32,7 @@ class LicenseReportExtension {
     public boolean unionParentPomLicenses
     public String outputDir
     public Project[] projects
+    public Project[] buildScriptProjects
     public ReportRenderer[] renderers
     public DependencyDataImporter[] importers
     public DependencyFilter[] filters
@@ -45,6 +47,7 @@ class LicenseReportExtension {
         unionParentPomLicenses = true
         outputDir = "${project.buildDir}/reports/dependency-license"
         projects = [project] + project.subprojects
+        buildScriptProjects = []
         renderers = new SimpleHtmlReportRenderer()
         configurations =
             project.getPlugins().hasPlugin('com.android.application') ? ['releaseRuntimeClasspath'] : ['runtimeClasspath']
@@ -76,6 +79,8 @@ class LicenseReportExtension {
         def snapshot = []
         snapshot << 'projects'
         snapshot += projects.collect { it.path }
+        snapshot << 'buildScriptProjects'
+        snapshot += buildScriptProjects.collect { it.path }
         snapshot << 'renderers'
         snapshot += renderers.collect { it.class.name }
         snapshot << 'importers'

--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -18,6 +18,24 @@ package com.github.jk1.license
 import groovy.transform.Canonical
 import groovy.transform.Sortable
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.initialization.dsl.ScriptHandler
+
+@Canonical
+class GradleProject {
+    String name
+    ConfigurationContainer configurations
+    DependencyHandler dependencies
+
+    static GradleProject ofProject(Project project) {
+        return new GradleProject(project.getName(), project.getConfigurations(), project.getDependencies());
+    }
+
+    static GradleProject ofScript(Project project) {
+        return new GradleProject(project.name + "/buildScript", project.buildscript.getConfigurations(), project.buildscript.getDependencies());
+    }
+}
 
 @Canonical
 class ProjectData {

--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -16,6 +16,7 @@
 package com.github.jk1.license.reader
 
 import com.github.jk1.license.ConfigurationData
+import com.github.jk1.license.GradleProject
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.task.ReportTask
 import org.gradle.api.Project
@@ -37,7 +38,7 @@ class ConfigurationReader {
         this.moduleReader = moduleReader
     }
 
-    ConfigurationData read(Project project, Configuration configuration) {
+    ConfigurationData read(GradleProject project, Configuration configuration) {
         ConfigurationData data = new ConfigurationData()
         data.name = configuration.name
 

--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.reader
 
+import com.github.jk1.license.GradleProject
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.task.ReportTask
@@ -25,7 +26,7 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
 interface ModuleReader {
-    ModuleData read(Project project, ResolvedDependency dependency)
+    ModuleData read(GradleProject project, ResolvedDependency dependency)
 }
 
 class ModuleReaderImpl implements ModuleReader {
@@ -43,7 +44,7 @@ class ModuleReaderImpl implements ModuleReader {
         this.filesReader = new LicenseFilesReader(config)
     }
 
-    ModuleData read(Project project, ResolvedDependency dependency) {
+    ModuleData read(GradleProject project, ResolvedDependency dependency) {
         ModuleData moduleData = new ModuleData(dependency.moduleGroup, dependency.moduleName, dependency.moduleVersion)
         dependency.moduleArtifacts.each { ResolvedArtifact artifact ->
             LOGGER.info("Processing artifact: $artifact ($artifact.file)")
@@ -71,7 +72,7 @@ class CachedModuleReader implements ModuleReader {
         this.actualReader = new ModuleReaderImpl(config)
     }
 
-    ModuleData read(Project project, ResolvedDependency dependency) {
+    ModuleData read(GradleProject project, ResolvedDependency dependency) {
         String dataName = "${dependency.moduleGroup}:${dependency.moduleName}:${dependency.moduleVersion}"
         return moduleDataCache.computeIfAbsent(dataName) {
             actualReader.read(project, dependency)

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.reader
 
+import com.github.jk1.license.GradleProject
 import com.github.jk1.license.License
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.PomData
@@ -45,7 +46,7 @@ class PomReader {
         this.config = config
     }
 
-    PomData readPomData(Project project, ResolvedArtifact artifact) {
+    PomData readPomData(GradleProject project, ResolvedArtifact artifact) {
         resolver = new CachingArtifactResolver(project)
         GPathResult pomContent = findAndSlurpPom(artifact.file)
         boolean pomRepresentsArtifact = true

--- a/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.render
 
+import com.github.jk1.license.GradleProject
 import com.github.jk1.license.ImportedModuleBundle
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ModuleData

--- a/src/main/groovy/com/github/jk1/license/task/CacheableReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CacheableReportTask.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.task
 
+import com.github.jk1.license.GradleProject
 import com.github.jk1.license.reader.ProjectReader
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.CacheableTask
@@ -25,8 +26,11 @@ class CacheableReportTask extends ReportTask {
 
     @Classpath
     FileCollection getClasspath() {
-        getConfig().projects
-            .collectMany { ProjectReader.findConfiguredConfigurations(it, getConfig()) }
-            .inject(project.files(), { FileCollection memo, eachConfiguration -> memo + eachConfiguration })
+        def projectConfigs = getConfig().projects
+                .collectMany { ProjectReader.findConfiguredConfigurations(GradleProject.ofProject(it), getConfig()) }
+        def buildScriptProjectConfigs = getConfig().buildScriptProjects
+                .collectMany { ProjectReader.findConfiguredConfigurations(GradleProject.ofScript(it), getConfig()) }
+        (projectConfigs + buildScriptProjectConfigs)
+                .inject(project.files(), { FileCollection memo, eachConfiguration -> memo + eachConfiguration })
     }
 }

--- a/src/main/groovy/com/github/jk1/license/util/CachingArtifactResolver.groovy
+++ b/src/main/groovy/com/github/jk1/license/util/CachingArtifactResolver.groovy
@@ -15,19 +15,17 @@
  */
 package com.github.jk1.license.util
 
-import org.gradle.api.Project
+import com.github.jk1.license.GradleProject
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ResolvedArtifact
 
-import java.util.concurrent.atomic.AtomicInteger
-
 class CachingArtifactResolver {
 
     private Map<Map<String, String>, Collection<ResolvedArtifact>> cache = new HashMap<>()
-    private Project project
+    private GradleProject project
 
-    CachingArtifactResolver(Project project) {
+    CachingArtifactResolver(GradleProject project) {
         this.project = project
     }
 

--- a/src/test/groovy/com/github/jk1/license/MultiProjectBuildScriptFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/MultiProjectBuildScriptFuncSpec.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license
+
+import org.gradle.testkit.runner.TaskOutcome
+
+import static com.github.jk1.license.reader.ProjectReaderFuncSpec.removeDevelopers
+
+class MultiProjectBuildScriptFuncSpec extends AbstractGradleRunnerFunctionalSpec {
+
+    def "plugin is executed in each module independently if configured for submodules"() {
+        setup:
+        settingsGradle = new File(testProjectDir, "settings.gradle")
+
+        newSubBuildFile("sub1") << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'org.owasp.dependencycheck' version '9.0.7'
+            }
+            configurations {
+                mainConfig
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                renderers = [new com.github.jk1.license.render.RawProjectDataJsonRenderer()]
+                filters = new com.github.jk1.license.filter.LicenseBundleNormalizer()
+                configurations = []
+                buildScriptProjects = [project] + project.subprojects
+            }
+        """
+
+        newSubBuildFile("sub2") << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'com.diffplug.spotless' version '6.24.0'
+            }
+            configurations {
+                mainConfig
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                renderers = [new com.github.jk1.license.render.RawProjectDataJsonRenderer()]
+                filters = new com.github.jk1.license.filter.LicenseBundleNormalizer()
+                configurations = []
+                buildScriptProjects = [project] + project.subprojects
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+        def sub1RawGPath = jsonSlurper.parse(new File(testProjectDir, "sub1/build/reports/dependency-license/raw-project-data.json"))
+        def sub2RawGPath = jsonSlurper.parse(new File(testProjectDir, "sub2/build/reports/dependency-license/raw-project-data.json"))
+        removeDevelopers(sub1RawGPath)
+        removeDevelopers(sub2RawGPath)
+        def configurationsSub1String = prettyPrintJson(sub1RawGPath.configurations)
+        def configurationsSub2String = prettyPrintJson(sub2RawGPath.configurations)
+
+        then:
+        runResult.task(":sub1:generateLicenseReport").outcome == TaskOutcome.SUCCESS
+        runResult.task(":sub2:generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        System.out.println(testProjectDir)
+        !new File(testProjectDir, "build/reports/dependency-license").exists()
+        new File(testProjectDir, "sub1/build/reports/dependency-license/dependency-check-core-9.0.7.jar/META-INF/LICENSE.txt").exists()
+        new File(testProjectDir, "sub2/build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/NOTICE.txt").exists()
+        new File(testProjectDir, "sub2/build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/LICENSE.txt").exists()
+
+        configurationsSub1String.contains("Dependency-Check Core")
+        !configurationsSub1String.contains("commons-codec")
+
+        configurationsSub2String.contains("commons-codec")
+        !configurationsSub2String.contains("Dependency-Check Core")
+    }
+
+    def "plugin is executed in module independently and globally on root project when configured in allprojects"() {
+        setup:
+        settingsGradle = new File(testProjectDir, "settings.gradle")
+
+        buildFile << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'com.github.ben-manes.versions' version '0.48.0'
+            }
+            configurations {
+                mainConfig
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                renderers = [new com.github.jk1.license.render.RawProjectDataJsonRenderer()]
+                filters = new com.github.jk1.license.filter.LicenseBundleNormalizer()
+                configurations = []
+                buildScriptProjects = [project] + project.subprojects
+            }
+"""
+
+        newSubBuildFile("sub1") << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'org.owasp.dependencycheck' version '9.0.7'
+            }
+            configurations {
+                mainConfig
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                renderers = [new com.github.jk1.license.render.RawProjectDataJsonRenderer()]
+                filters = new com.github.jk1.license.filter.LicenseBundleNormalizer()
+                configurations = []
+                buildScriptProjects = [project] + project.subprojects
+            }
+        """
+
+        newSubBuildFile("sub2") << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'com.diffplug.spotless' version '6.24.0'
+            }
+            configurations {
+                mainConfig
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            import com.github.jk1.license.render.*
+            licenseReport {
+                renderers = [new com.github.jk1.license.render.RawProjectDataJsonRenderer()]
+                filters = new com.github.jk1.license.filter.LicenseBundleNormalizer()
+                configurations = []
+                buildScriptProjects = [project] + project.subprojects
+            }
+        """
+
+        when:
+        def runResult = runGradleBuild()
+        def rootRawGPath = jsonSlurper.parse(new File(testProjectDir, "build/reports/dependency-license/raw-project-data.json"))
+        def sub1RawGPath = jsonSlurper.parse(new File(testProjectDir, "sub1/build/reports/dependency-license/raw-project-data.json"))
+        def sub2RawGPath = jsonSlurper.parse(new File(testProjectDir, "sub2/build/reports/dependency-license/raw-project-data.json"))
+        def configurationsRootString = prettyPrintJson(rootRawGPath.configurations)
+        def configurationsSub1String = prettyPrintJson(sub1RawGPath.configurations)
+        def configurationsSub2String = prettyPrintJson(sub2RawGPath.configurations)
+
+        then:
+        runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+        runResult.task(":sub1:generateLicenseReport").outcome == TaskOutcome.SUCCESS
+        runResult.task(":sub2:generateLicenseReport").outcome == TaskOutcome.SUCCESS
+
+        // root project should contains all the deps
+        new File(testProjectDir, "build/reports/dependency-license/mxparser-1.2.2.jar/META-INF/LICENSE").exists()
+        new File(testProjectDir, "build/reports/dependency-license/dependency-check-core-9.0.7.jar/META-INF/LICENSE.txt").exists()
+        new File(testProjectDir, "build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/NOTICE.txt").exists()
+        new File(testProjectDir, "build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/LICENSE.txt").exists()
+
+        new File(testProjectDir, "sub1/build/reports/dependency-license/dependency-check-core-9.0.7.jar/META-INF/LICENSE.txt").exists()
+
+        new File(testProjectDir, "sub2/build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/NOTICE.txt").exists()
+        new File(testProjectDir, "sub2/build/reports/dependency-license/commons-codec-1.16.0.jar/META-INF/LICENSE.txt").exists()
+
+        configurationsRootString.contains("Dependency-Check Core")
+        configurationsRootString.contains("commons-codec")
+        configurationsRootString.contains("mxparser")
+
+        configurationsSub1String.contains("Dependency-Check Core")
+        !configurationsSub1String.contains("commons-codec")
+        !configurationsSub1String.contains("mxparser")
+
+        !configurationsSub2String.contains("Dependency-Check Core")
+        configurationsSub2String.contains("commons-codec")
+        !configurationsSub2String.contains("mxparser")
+
+
+    }
+}


### PR DESCRIPTION
In our project, we need to scan also the build-time dependencies for licenses. In gradle they can be access via `project.buildScript`.

For this, the buildScriptProjects configuration option was introduced. It respects all other configuration like 'configurations'.

The implementation is utilizing the existing ProjectReader for this because the required fields (`configurations` and `dependencies`) can also be found in ScriptHandler. There is only a change required: to use a general data structure for accessing these fields.