### PR TITLE
Support of Kotlin Multiplatform Modules

### DIFF
--- a/samples/kotlin/build.gradle.kts
+++ b/samples/kotlin/build.gradle.kts
@@ -1,10 +1,12 @@
 import com.github.jk1.license.render.ReportRenderer
 import com.github.jk1.license.render.InventoryHtmlReportRenderer
+import com.github.jk1.license.render.JsonReportRenderer
 import com.github.jk1.license.filter.DependencyFilter
 import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.filter.ExcludeDependenciesWithoutArtifactsFilter
 
 plugins {
-    id("com.github.jk1.dependency-license-report") version "1.13"
+    id("com.github.jk1.dependency-license-report") version "2.5"
     id("java")
 }
 
@@ -17,9 +19,16 @@ dependencies {
     implementation("com.sun.mail:javax.mail:1.5.4")
     implementation("org.ehcache:ehcache:3.3.1")
     implementation("org.apache.geronimo.specs:geronimo-jta_1.0.1B_spec:1.0.1")
+    implementation("io.ktor:ktor-io:2.3.6")
 }
 
 licenseReport {
-    renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("report.html","Backend"))
-    filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
+    renderers = arrayOf<ReportRenderer>(
+        InventoryHtmlReportRenderer("report.html","Backend"),
+        JsonReportRenderer("report.json", true),
+        )
+    filters = arrayOf<DependencyFilter>(
+        LicenseBundleNormalizer(),
+        ExcludeDependenciesWithoutArtifactsFilter(),
+    )
 }

--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -40,6 +40,7 @@ class ConfigurationData {
 @Canonical
 class ModuleData {
     String group, name, version
+    boolean hasArtifactFile
     Set<ManifestData> manifests = new TreeSet<ManifestData>()
     Set<LicenseFileData> licenseFiles = new TreeSet<LicenseFileData>()
     Set<PomData> poms = new TreeSet<PomData>()

--- a/src/main/groovy/com/github/jk1/license/filter/ExcludeDependenciesWithoutArtifactsFilter.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/ExcludeDependenciesWithoutArtifactsFilter.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jk1.license.filter;
+
+import com.github.jk1.license.*;
+
+/**
+ * This class is designed to function as a filter for removing dependencies from a report that are not associated
+ * with any artifacts. For instance, Kotlin Multiplatform modules will be excluded, while platform-specific modules
+ * will be retained in the report.
+ */
+class ExcludeDependenciesWithoutArtifactsFilter implements DependencyFilter {
+    @Override
+    ProjectData filter(ProjectData source) {
+        def configurations = source.configurations
+                .collect { c ->
+                    new ConfigurationData(c.name, c.dependencies.findAll { it.hasArtifactFile })
+                }
+                .toSet()
+
+        return new ProjectData(source.project, configurations, source.importedModules);
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -47,7 +47,8 @@ class ModuleReaderImpl implements ModuleReader {
         ModuleData moduleData = new ModuleData(dependency.moduleGroup, dependency.moduleName, dependency.moduleVersion)
         dependency.moduleArtifacts.each { ResolvedArtifact artifact ->
             LOGGER.info("Processing artifact: $artifact ($artifact.file)")
-            if (artifact.file.exists()){
+            moduleData.hasArtifactFile = artifact.file.exists()
+            if (moduleData.hasArtifactFile){
                 def pom = pomReader.readPomData(project, artifact)
                 def manifest = manifestReader.readManifestData(artifact)
                 def licenseFile = filesReader.read(artifact)

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -194,6 +194,10 @@ class ProjectBuilder extends BuilderSupport {
         }
     }
 
+    private def setHasArtifactFile(boolean value) {
+        current.hasArtifactFile = value
+    }
+
     private License addPomLicense(Object license, Map map) {
         PomData pom = (PomData)current
 

--- a/src/test/groovy/com/github/jk1/license/filter/ExcludeDependenciesWithoutArtifactsFilterSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/ExcludeDependenciesWithoutArtifactsFilterSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jk1.license.filter
+
+import com.github.jk1.license.ProjectBuilder
+import com.github.jk1.license.ProjectData
+import spock.lang.Specification
+
+import static com.github.jk1.license.ProjectBuilder.json
+
+class ExcludeDependenciesWithoutArtifactsFilterSpec extends Specification {
+    def filter = new ExcludeDependenciesWithoutArtifactsFilter()
+    ProjectBuilder builder = new ProjectBuilder()
+
+    def "modules without artifacts should be deleted"() {
+        ProjectData projectData = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    hasArtifactFile = true
+                }
+                module("mod2") {
+                    hasArtifactFile = false
+                }
+            }
+            configuration("test") {
+                module("mod3") {
+                    hasArtifactFile = false
+                }
+            }
+        }
+
+        ProjectData expected = builder.project {
+            configuration("runtime") {
+                module("mod1") {
+                    hasArtifactFile = true
+                }
+            }
+            configuration("test")
+        }
+
+
+        when:
+        def result = filter.filter(projectData)
+
+        then:
+        json(result) == json(expected)
+    }
+}


### PR DESCRIPTION
Currently KMP modules displayed in report without license and url (just name and version).

I implemented a filter which allows to filter dependencies without artifact files, so KMP modules will be filtered out.

Initial issue:
https://github.com/jk1/Gradle-License-Report/issues/272