### PR TITLE
Avoid computations in the Constructor of LicenseBundleNormalizer and InventoryReportRenderer

### DIFF
--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -37,6 +37,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
     private static Logger LOGGER = Logging.getLogger(ReportTask.class)
 
+    protected String bundlePath
+    protected boolean createDefaultTransformationRules
+    protected boolean isInitialized
+
+    // following properties will only exist after the class is initialized
     protected String filterConfig = ""
     protected ReduceDuplicateLicensesFilter duplicateFilter = new ReduceDuplicateLicensesFilter()
     protected LicenseReportExtension config
@@ -51,6 +56,15 @@ class LicenseBundleNormalizer implements DependencyFilter {
     }
 
     LicenseBundleNormalizer(String bundlePath, boolean createDefaultTransformationRules) {
+        this.bundlePath = bundlePath
+        this.createDefaultTransformationRules = createDefaultTransformationRules
+    }
+
+    synchronized void init() {
+        if (isInitialized) {
+            return
+        }
+        isInitialized = true
         LOGGER.debug("This build has requested module license bundle normalization")
 
         filterConfig += "bundlePath = $bundlePath\n"
@@ -80,6 +94,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
     @Override
     ProjectData filter(ProjectData data) {
+        init()
         LOGGER.debug("Performing module license normalization")
         config = data.project.licenseReport
 

--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -22,10 +22,8 @@ import org.gradle.api.logging.Logging
 
 class InventoryHtmlReportRenderer extends InventoryReportRenderer {
 
-    InventoryHtmlReportRenderer(String fileName = 'index.html', String name = null, File overridesFilename = null) {
-        this.name = name
-        this.fileName = fileName
-        if (overridesFilename) overrides = parseOverrides(overridesFilename)
+    InventoryHtmlReportRenderer(String fileName = 'index.html', String name = null, File overridesFile = null) {
+        super(fileName, name, overridesFile)
     }
 
     @Override

--- a/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
@@ -25,10 +25,8 @@ import com.github.jk1.license.ProjectData
 
 class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
 
-    InventoryMarkdownReportRenderer(String fileName = 'licenses.md', String name = null, File overridesFilename = null) {
-        this.name = name
-        this.fileName = fileName
-        if (overridesFilename) overrides = parseOverrides(overridesFilename)
+    InventoryMarkdownReportRenderer(String fileName = 'licenses.md', String name = null, File overridesFile = null) {
+        super(fileName, name, overridesFile)
     }
 
     @Override


### PR DESCRIPTION

This should be avoided for two reasons:
1. it is called even when the module is not used
2. it gives less freedom for configuration: e.g. a user wants to configure it with a file, which does not yet exist because it will be created in a different task