### PR TITLE
implement 'requireAllLicensesAllowed' config option to change how dependency licenses are matched against allowedLicenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ licenseReport {
     // This is for the allowed-licenses-file in checkLicense Task
     // Accepts File, URL or String path to local or remote file
     allowedLicensesFile = new File("$projectDir/config/allowed-licenses.json")
+
+    // When false is set, a dependency is good, if any of its licenses are matched with allowedLicenses
+    // When true is set, a dependency is good, if all of its licenses are matched with allowedLicenses
+    // default is false, but true is recommended.
+    requireAllLicensesAllowed = false
 }
 ```
 

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -41,6 +41,7 @@ class LicenseReportExtension {
     public String[] excludeGroups
     public String[] excludes
     public Object allowedLicensesFile
+    public boolean requireAllLicensesAllowed
 
     LicenseReportExtension(Project project) {
         unionParentPomLicenses = true
@@ -55,6 +56,7 @@ class LicenseReportExtension {
         excludes = []
         importers = []
         filters = []
+        requireAllLicensesAllowed = false
     }
 
     @Nested
@@ -104,6 +106,8 @@ class LicenseReportExtension {
         snapshot += excludes
         snapshot << 'unionParentPomLicenses'
         snapshot += unionParentPomLicenses
+        snapshot << "requireAllLicensesAllowed"
+        snapshot += requireAllLicensesAllowed
         snapshot.join("!")
     }
 

--- a/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
+++ b/src/main/groovy/com/github/jk1/license/check/LicenseChecker.groovy
@@ -18,70 +18,92 @@ package com.github.jk1.license.check
 import groovy.json.JsonOutput
 import org.gradle.api.GradleException
 
+/**
+ * This class compares the found licences with the allowed licenses and creates a report for any missing license
+ */
 class LicenseChecker {
-
-    void checkAllDependencyLicensesAreAllowed(
-        Object allowedLicensesFile, File projectLicensesDataFile, File notPassedDependenciesOutputFile) {
+    static void checkAllDependencyLicensesAreAllowed(
+            Object allowedLicensesFile,
+            File projectLicensesDataFile,
+            boolean requireAllLicensesAllowed,
+            File notPassedDependenciesOutputFile) {
         List<Dependency> allDependencies = LicenseCheckerFileReader.importDependencies(projectLicensesDataFile)
+        removeNullLicenses(allDependencies)
         List<AllowedLicense> allowedLicenses = LicenseCheckerFileReader.importAllowedLicenses(allowedLicensesFile)
-        List<Dependency> notPassedDependencies = searchForNotAllowedDependencies(allDependencies, allowedLicenses)
+        List<Tuple2<Dependency, List<ModuleLicense>>> notPassedDependencies = getNotAllowedLicenses(allDependencies, allowedLicenses)
+        if (!requireAllLicensesAllowed) {
+            // when we do not check for all Licenses allowed, we can filter out all dependencies here which had a partial match:
+            // this means, when the size of notPassedLicenses differs, at least one license matched with our allowed-list
+            notPassedDependencies = notPassedDependencies.findAll { it.get(0).moduleLicenses == null || it.get(1).size() == it.get(0).moduleLicenses.size() }
+        }
         generateNotPassedDependenciesFile(notPassedDependencies, notPassedDependenciesOutputFile)
 
         if (!notPassedDependencies.isEmpty()) {
-            throw new GradleException("Some library licenses are not allowed.\n" +
-                "Read [$notPassedDependenciesOutputFile.path] for more information.")
+            throw new GradleException("Some library licenses are not allowed:\n" +
+                    "$notPassedDependenciesOutputFile.text\n\n" +
+                    "Read [$notPassedDependenciesOutputFile.path] for more information.")
         }
     }
 
-    private List<Dependency> searchForNotAllowedDependencies(
-        List<Dependency> dependencies, List<AllowedLicense> allowedLicenses) {
-        return dependencies.findAll { !isDependencyHasAllowedLicense(it, allowedLicenses) }
+    /**
+     * removes 'null'-licenses from dependencies which have at least one more license
+     */
+    private static void removeNullLicenses(List<Dependency> dependencies) {
+        for (Dependency dependency : dependencies) {
+            if (dependency.moduleLicenses.any { it.moduleLicense == null } && !dependency.moduleLicenses.every { it.moduleLicense == null }) {
+                dependency.moduleLicenses = dependency.moduleLicenses.findAll { it.moduleLicense != null }
+            }
+        }
     }
 
-    private void generateNotPassedDependenciesFile(
-        List<Dependency> notPassedDependencies, File notPassedDependenciesOutputFile) {
+    private static List<Tuple2<Dependency, List<ModuleLicense>>> getNotAllowedLicenses(List<Dependency> dependencies, List<AllowedLicense> allowedLicenses) {
+        List<Tuple2<Dependency, List<ModuleLicense>>> result = new ArrayList<>()
+        for (Dependency dependency : dependencies) {
+            List<AllowedLicense> perDependencyAllowedLicenses = allowedLicenses.findAll { isDependencyNameMatchesAllowedLicense(dependency, it) && isDependencyVersionMatchesAllowedLicense(dependency, it) }
+            // allowedLicense matches anything, so we don't need to further check
+            if (perDependencyAllowedLicenses.any { it.moduleLicense == null || it.moduleLicense == ".*" }) {
+                continue
+            }
+            def notAllowedLicenses = dependency.moduleLicenses.findAll { !isDependencyLicenseMatchesAllowedLicense(it, perDependencyAllowedLicenses) }
+            if (!notAllowedLicenses.isEmpty()) {
+                result.add(Tuple2.of(dependency, notAllowedLicenses))
+            }
+        }
+        return result
+    }
+
+    private static void generateNotPassedDependenciesFile(
+            List<Tuple2<Dependency, List<ModuleLicense>>> notPassedDependencies, File notPassedDependenciesOutputFile) {
         notPassedDependenciesOutputFile.text =
-            JsonOutput.prettyPrint(JsonOutput.toJson(
-                ["dependenciesWithoutAllowedLicenses": notPassedDependencies.collect { toAllowedLicenseList(it) }.flatten()]))
+                JsonOutput.prettyPrint(JsonOutput.toJson(
+                        ["dependenciesWithoutAllowedLicenses": notPassedDependencies.collect { toAllowedLicenseList(it.get(0), it.get(1)) }.flatten()]))
     }
 
-    private boolean isDependencyHasAllowedLicense(Dependency dependency, List<AllowedLicense> allowedLicenses) {
-        for(allowedLicense in allowedLicenses) {
-            if (isDependencyMatchesAllowedLicense(dependency, allowedLicense)) return true
+    private static boolean isDependencyNameMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        return dependency.moduleName ==~ allowedLicense.moduleName || allowedLicense.moduleName == null ||
+                dependency.moduleName == allowedLicense.moduleName
+    }
+
+    private static boolean isDependencyVersionMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
+        return dependency.moduleVersion ==~ allowedLicense.moduleVersion || allowedLicense.moduleVersion == null ||
+                dependency.moduleVersion == allowedLicense.moduleVersion
+    }
+
+    private static boolean isDependencyLicenseMatchesAllowedLicense(ModuleLicense moduleLicense, List<AllowedLicense> allowedLicenses) {
+        for (AllowedLicense allowedLicense : allowedLicenses) {
+            if (allowedLicense.moduleLicense == null || allowedLicense.moduleLicense == ".*") return true
+
+            if (moduleLicense.moduleLicense ==~ allowedLicense.moduleLicense ||
+                    moduleLicense.moduleLicense == allowedLicense.moduleLicense) return true
         }
         return false
     }
 
-    private boolean isDependencyMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
-        return isDependencyNameMatchesAllowedLicense(dependency, allowedLicense) &&
-            isDependencyLicenseMatchesAllowedLicense(dependency, allowedLicense) &&
-            isDependencyVersionMatchesAllowedLicense(dependency, allowedLicense)
-    }
-
-    private boolean isDependencyNameMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
-        return dependency.moduleName ==~ allowedLicense.moduleName || allowedLicense.moduleName == null ||
-            dependency.moduleName == allowedLicense.moduleName
-    }
-
-    private boolean isDependencyVersionMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
-        return dependency.moduleVersion ==~ allowedLicense.moduleVersion || allowedLicense.moduleVersion == null ||
-            dependency.moduleVersion == allowedLicense.moduleVersion
-    }
-
-    private boolean isDependencyLicenseMatchesAllowedLicense(Dependency dependency, AllowedLicense allowedLicense) {
-        if (allowedLicense.moduleLicense == null || allowedLicense.moduleLicense == ".*") return true
-
-        for (moduleLicenses in dependency.moduleLicenses)
-            if (moduleLicenses.moduleLicense ==~ allowedLicense.moduleLicense ||
-                moduleLicenses.moduleLicense == allowedLicense.moduleLicense) return true
-        return false
-    }
-
-    private List<AllowedLicense> toAllowedLicenseList(Dependency dependency) {
-        if (dependency.moduleLicenses.isEmpty()) {
-            return [ new AllowedLicense(dependency.moduleName, dependency.moduleVersion, null) ]
+    private static List<AllowedLicense> toAllowedLicenseList(Dependency dependency, List<ModuleLicense> moduleLicenses) {
+        if (moduleLicenses.isEmpty()) {
+            return [new AllowedLicense(dependency.moduleName, dependency.moduleVersion, null)]
         } else {
-            return dependency.moduleLicenses.collect { new AllowedLicense(dependency.moduleName, dependency.moduleVersion, it.moduleLicense) }
+            return moduleLicenses.findAll { it }.collect { new AllowedLicense(dependency.moduleName, dependency.moduleVersion, it.moduleLicense) }
         }
     }
 }

--- a/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
@@ -53,6 +53,11 @@ class CheckLicenseTask extends DefaultTask {
         return new File("${config.absoluteOutputDir}/${PROJECT_JSON_FOR_LICENSE_CHECKING_FILE}")
     }
 
+    @Input
+    boolean isRequireAllLicensesAllowed() {
+        return config.requireAllLicensesAllowed
+    }
+
     @OutputFile
     File getNotPassedDependenciesFile() {
         new File("${config.absoluteOutputDir}/$NOT_PASSED_DEPENDENCIES_FILE")
@@ -64,6 +69,10 @@ class CheckLicenseTask extends DefaultTask {
         LicenseChecker licenseChecker = new LicenseChecker()
         LOGGER.info("Check licenses if they are allowed to use.")
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            getAllowedLicenseFile(), getProjectDependenciesData(), notPassedDependenciesFile)
+                getAllowedLicenseFile(),
+                getProjectDependenciesData(),
+                isRequireAllLicensesAllowed(),
+                notPassedDependenciesFile
+        )
     }
 }

--- a/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/check/LicenseCheckerSpec.groovy
@@ -127,7 +127,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -163,7 +163,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
 
@@ -200,7 +200,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -232,7 +232,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -309,7 +309,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -343,7 +343,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -381,7 +381,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -416,7 +416,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -455,7 +455,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -484,7 +484,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
 
         then:
@@ -515,7 +515,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
 
         then:
@@ -551,7 +551,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -588,7 +588,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -622,7 +622,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -659,7 +659,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -697,7 +697,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -732,7 +732,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -770,7 +770,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -804,7 +804,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
@@ -848,7 +848,7 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         noExceptionThrown()
@@ -883,12 +883,162 @@ class LicenseCheckerSpec extends Specification {
         when:
         def licenseChecker = new LicenseChecker()
         licenseChecker.checkAllDependencyLicensesAreAllowed(
-            allowedLicenseFile, projectDataFile, notPassedDependenciesFile)
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
 
         then:
         def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
         notPassedDependencies.moduleName == ["dummy-group:mod1", "dummy-group:mod1", "dummy-group:mod1"]
         notPassedDependencies.moduleLicense == ["License1", "License2", "License3"]
         thrown GradleException
+    }
+
+    def "check when ProjectData contains multiple licenses and CheckType is configured to require all licenses to match."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                {
+                    "moduleLicense": "License3",
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                {
+                    "moduleLicenses": [
+                        {"moduleLicense": "License1"},
+                        {"moduleLicense": "License2"},
+                        {"moduleLicense": "License3"}
+                    ],
+                "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+                allowedLicenseFile, projectDataFile, true, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1", "dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["License1", "License2"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains multiple licenses with one of them 'null' and CheckType is configured to require all licenses to match."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                {
+                    "moduleLicense": "License3",
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                {
+                    "moduleLicenses": [
+                        {"moduleLicense": null},
+                        {"moduleLicense": "License2"},
+                        {"moduleLicense": "License3"}
+                    ],
+                "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+                allowedLicenseFile, projectDataFile, true, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == ["License2"]
+        thrown GradleException
+    }
+
+    def "check when ProjectData contains one license with 'null' and CheckType is configured to require all licenses to match."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                {
+                    "moduleLicense": "License3",
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                {
+                    "moduleLicenses": [
+                        {"moduleLicense": null}
+                    ],
+                "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+                allowedLicenseFile, projectDataFile, true, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == ["dummy-group:mod1"]
+        notPassedDependencies.moduleLicense == [null]
+        thrown GradleException
+    }
+
+
+    def "check when ProjectData contains multiple licenses and CheckType is configured to require any licenses to match."() {
+
+        allowedLicenseFile << """
+        {
+            "allowedLicenses":[
+                {
+                    "moduleLicense": "License3",
+                    "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        projectDataFile << """
+        {
+            "dependencies":[
+                {
+                    "moduleLicenses": [
+                        {"moduleLicense": "License1"},
+                        {"moduleLicense": "License2"},
+                        {"moduleLicense": "License3"}
+                    ],
+                "moduleName": "dummy-group:mod1"
+                }
+            ]
+        }"""
+
+        when:
+        def licenseChecker = new LicenseChecker()
+        licenseChecker.checkAllDependencyLicensesAreAllowed(
+                allowedLicenseFile, projectDataFile, false, notPassedDependenciesFile)
+
+        then:
+        def notPassedDependencies = importNotPassedDependencies(notPassedDependenciesFile)
+        notPassedDependencies.moduleName == []
+        notPassedDependencies.moduleLicense == []
     }
 }


### PR DESCRIPTION
The default behavior is that a dependency is fine when any of its licenses are found inside allowedLicenses. This may miss dependencies, which contain multiple licenses.

When 'requireAllLicensesAllowed' is set to true, it will only approve a dependency when all of its discovered licenses are found in the allowedLicenses. This may report false-positives for dependencies which are dual-licensed. But in general I think a false-positive is better than missing a license violation.

This fixes #285