### PR TITLE
Fix kotlin Multiplatform Test: The test requires Java 17 but in our github action we only have 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ licenseReport {
    
     // Set output directory for the report data.
     // Defaults to ${project.buildDir}/reports/dependency-license.
-    outputDir = "$projectDir/build/licenses"
+    outputDir = project.layout.buildDirectory.dir("licenses").get().asFile.path
 
     // Select projects to examine for dependencies.
     // Defaults to current project and all its subprojects
@@ -84,7 +84,7 @@ licenseReport {
 
     // This is for the allowed-licenses-file in checkLicense Task
     // Accepts File, URL or String path to local or remote file
-    allowedLicensesFile = new File("$projectDir/config/allowed-licenses.json")
+    allowedLicensesFile = project.layout.projectDirectory.file("config/allowed-licenses.json").asFile
 }
 ```
 

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -44,7 +44,7 @@ class LicenseReportExtension {
 
     LicenseReportExtension(Project project) {
         unionParentPomLicenses = true
-        outputDir = "${project.buildDir}/reports/dependency-license"
+        outputDir = project.layout.buildDirectory.dir("reports/dependency-license").get().asFile.absolutePath
         projects = [project] + project.subprojects
         renderers = new SimpleHtmlReportRenderer()
         configurations =
@@ -77,7 +77,7 @@ class LicenseReportExtension {
         if (new File(outputDir).isAbsolute()) {
             return outputDir
         } else {
-            return projects.first().absoluteProjectPath(outputDir)
+            return projects.first().layout.projectDirectory.dir(outputDir).asFile.absolutePath
         }
     }
 

--- a/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/MultiProjectReaderFuncSpec.groovy
@@ -580,7 +580,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
         newSubBuildFile("shared") << """
             plugins {
-                id "com.android.library" version "8.1.3"
+                id "com.android.library" version "7.4.0"
                 id "org.jetbrains.kotlin.multiplatform" version "1.9.20"
                 id "com.github.jk1.dependency-license-report"
             }
@@ -629,7 +629,7 @@ class MultiProjectReaderFuncSpec  extends AbstractGradleRunnerFunctionalSpec {
 
         newSubBuildFile("android") << """
             plugins {
-                id "com.android.application" version "8.1.3"
+                id "com.android.application" version "7.4.0"
                 id "org.jetbrains.kotlin.android" version "1.9.20"
                 id "com.github.jk1.dependency-license-report"
             }


### PR DESCRIPTION
By downgrading the android-gradle plugin, it also runs with java 11

also fixed how the absolute path is computed for a relative output directory. This was failing in the test.

And replaced the deprecated projectDir/buildDir variables: https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_builddir_can_cause_script_compilation_failure