### PR TITLE
fix missing artifact resolver for the bom-resolution

### DIFF
--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -69,7 +69,7 @@ class ModuleReaderImpl implements ModuleReader {
             extraPomResults.each { ResolvedArtifactResult artifact ->
                 LOGGER.info("Processing artifact: $artifact ($artifact.file)")
                 if (artifact.file.exists()) {
-                    def pom = pomReader.readPomData(artifact)
+                    def pom = pomReader.readPomData(project, artifact)
                     if (pom) moduleData.poms << pom
                 } else {
                     LOGGER.info("Skipping artifact file $artifact.file as it does not exist")

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -74,7 +74,8 @@ class PomReader {
         }
     }
 
-    PomData readPomData(ResolvedArtifactResult artifact) {
+    PomData readPomData(Project project, ResolvedArtifactResult artifact) {
+        resolver = new CachingArtifactResolver(project)
         GPathResult pomContent = findAndSlurpPom(artifact.file)
         return readPomFile(pomContent)
     }

--- a/src/test/groovy/com/github/jk1/license/reader/PomDependencyResolutionFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/PomDependencyResolutionFuncSpec.groovy
@@ -56,6 +56,7 @@ class PomDependencyResolutionFuncSpec extends AbstractGradleRunnerFunctionalSpec
 
         then:
         runResult.task(":generateLicenseReport").outcome == TaskOutcome.SUCCESS
+        // 2 licenses because it also resolves jackson-parent, which has its own license
         configurationsString == """[
     {
         "dependencies": [
@@ -80,6 +81,10 @@ class PomDependencyResolutionFuncSpec extends AbstractGradleRunnerFunctionalSpec
                             {
                                 "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
                                 "name": "Apache License, Version 2.0"
+                            },
+                            {
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": "The Apache Software License, Version 2.0"
                             }
                         ]
                     }


### PR DESCRIPTION
This issue was introduced with PR #287.
When calling the pomReader, the resolver was not always set and caused several (non-critical) exceptions in the log. Like:
```
Failed to retrieve artifacts for [group:com.google.code.gson, name:gson-parent, version:2.10.1, ext:pom]
java.lang.NullPointerException: Cannot invoke method resolveArtifacts() on null object


Failed to retrieve artifacts for [group:com.fasterxml.jackson, name:jackson-parent, version:2.16, ext:pom]
java.lang.NullPointerException: Cannot invoke method resolveArtifacts() on null object

Failed to retrieve artifacts for [group:software.amazon.awssdk, name:aws-sdk-java-pom, version:2.23.15, ext:pom]
java.lang.NullPointerException: Cannot invoke method resolveArtifacts() on null object
```
Those come frome the parents of the resolved bom-poms. This was due to having no `resolver` initialized.

After the change, it could resolved jackson-parent in the test and also added its license to the result. That's why the test changed slightly.