### PR TITLE
fix missing override for InventoryReportRenderer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'adopt'
@@ -24,7 +24,8 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew test
     - name: Unit tests results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: unit-tests-results
         path: build/reports/tests/test

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation localGroovy()
 
     testImplementation gradleTestKit()
-    testImplementation('org.spockframework:spock-core:2.1-groovy-3.0') {
+    testImplementation('org.spockframework:spock-core:2.4-M4-groovy-3.0') {
         exclude group: 'org.codehaus.groovy'
     }
 }
@@ -39,6 +39,10 @@ test {
         showStandardStreams = true
         exceptionFormat = 'full'
     }
+    systemProperty("spock.snapshots.rootPath", "src/test/resources")
+    systemProperty("spock.snapshots.updateSnapshots", !System.getenv("CI"))
+    systemProperty("spock.snapshots.writeActualSnapshotOnMismatch", !System.getenv("CI"))
+
     outputs.upToDateWhen { false }
 }
 

--- a/src/test/groovy/com/github/jk1/license/ProjectDataFixture.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectDataFixture.groovy
@@ -30,8 +30,13 @@ class ProjectDataFixture {
 
     static License APACHE2_LICENSE() {
         new License(
-            name: "Apache License, Version 2.0",
-            url: "https://www.apache.org/licenses/LICENSE-2.0"
+                name: "Apache License, Version 2.0",
+                url: "https://www.apache.org/licenses/LICENSE-2.0"
+        )
+    }
+    static License UNKNOWN_LICENSE() {
+        new License(
+                name: "Unknown"
         )
     }
     static License MIT_LICENSE() {

--- a/src/test/groovy/com/github/jk1/license/render/AbstractInventoryReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/AbstractInventoryReportRendererSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.render
+
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ProjectBuilder
+import com.github.jk1.license.ProjectData
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import static com.github.jk1.license.ProjectDataFixture.*
+
+class AbstractInventoryReportRendererSpec extends Specification {
+
+    @TempDir
+    File testProjectDir
+    File outputFile
+    File overrides
+
+    ProjectBuilder builder = new ProjectBuilder()
+    ProjectData projectData
+
+    def setup() {
+        outputFile = new File(testProjectDir, "output")
+        outputFile.delete()
+        overrides = new File(testProjectDir, "overrides.txt")
+        overrides.text = "dummy-group:mod2:0.0.1|https://projecturl|Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt"
+
+        LicenseReportExtension extension = GRADLE_PROJECT().licenseReport
+        extension.outputDir = testProjectDir
+
+        // copy apache2 license file
+        def apache2LicenseFile = new File(getClass().getResource('/apache2.license').toURI())
+        new File(testProjectDir, "apache2.license") << apache2LicenseFile.text
+
+        projectData = builder.project {
+            configurations(["runtime", "test"]) { configName ->
+                configuration(configName) {
+                    module("mod1") {
+                        pom("pom1") {
+                            license(APACHE2_LICENSE(), url: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org/licenses/LICENSE-2.0")
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0")
+                        }
+                    }
+                    module("mod2") {
+                        pom("pom2") {
+                            license(UNKNOWN_LICENSE())
+                        }
+                    }
+                    module("mod3") {
+                        pom("pom3") {
+                            license(UNKNOWN_LICENSE())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/AbstractInventoryReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/AbstractInventoryReportRendererSpec.groovy
@@ -18,6 +18,8 @@ package com.github.jk1.license.render
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ProjectBuilder
 import com.github.jk1.license.ProjectData
+import spock.lang.Snapshot
+import spock.lang.Snapshotter
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -25,6 +27,8 @@ import static com.github.jk1.license.ProjectDataFixture.*
 
 class AbstractInventoryReportRendererSpec extends Specification {
 
+    @Snapshot
+    Snapshotter snapshotter
     @TempDir
     File testProjectDir
     File outputFile
@@ -70,6 +74,27 @@ class AbstractInventoryReportRendererSpec extends Specification {
                             license(UNKNOWN_LICENSE())
                         }
                     }
+
+                    module("mod4") {
+                        pom("pom2") {
+                            license(APACHE2_LICENSE())
+                        }
+                        pom("pom3") {
+                            license(APACHE2_LICENSE())
+                            license(MIT_LICENSE())
+                        }
+                        licenseFiles {
+                            licenseFileDetails(file: "apache2.license", license: "Apache License, Version 2.0", licenseUrl: "https://www.apache.org / licenses / LICENSE - 2.0 ")
+                        }
+                        manifest("mani1") {
+                            license("Apache 2.0")
+                        }
+                    }
+                }
+
+                importedModulesBundle("bundle1") {
+                    importedModule(name: "mod1", license: "Apache  2", licenseUrl: "apache-url")
+                    importedModule(name: "mod2", license: "Apache  2", licenseUrl: "apache-url")
                 }
             }
         }

--- a/src/test/groovy/com/github/jk1/license/render/InventoryHtmlReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/InventoryHtmlReportRendererSpec.groovy
@@ -25,25 +25,7 @@ class InventoryHtmlReportRendererSpec extends AbstractInventoryReportRendererSpe
 
         then:
         outputFile.exists()
-        outputFile.text.stripIndent().contains("""<h2>Apache License, Version 2.0</h2>
-<div class='dependency'>
-<p><strong> 1.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod1 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
-<div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
-<label>Manifest License</label>
-<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
-<label>POM Project URL</label>
-<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
-<label>POM License</label>
-<div class='dependency-value'>Apache License, Version 2.0 - <a href='https://www.apache.org/licenses/LICENSE-2.0'>https://www.apache.org/licenses/LICENSE-2.0</a></div>
-  - Embedded license files:
-    - apache2.license</div>
-<div class='dependency'>
-<p><strong> 2.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod2 <strong>Version:</strong> 0.0.1 </p><label>Project URL</label>
-<div class='dependency-value'><a href='https://projecturl'>https://projecturl</a></div>
-<label>License URL</label>
-<div class='dependency-value'><a href='http://www.apache.org/licenses/LICENSE-2.0.txt'>Apache License, Version 2.0</a></div>""")
-        outputFile.text.stripIndent().contains("""<h2>Unknown</h2>
-<div class='dependency'>
-<p><strong> 3.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod3 <strong>Version:</strong> 0.0.1 </p><label>POM Project URL</label>""")
+        def sanitizedOutput = outputFile.text.replaceAll("<em>[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z0-9-]+</em>", "DATE")
+        snapshotter.assertThat(sanitizedOutput).matchesSnapshot()
     }
 }

--- a/src/test/groovy/com/github/jk1/license/render/InventoryHtmlReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/InventoryHtmlReportRendererSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.render
+
+class InventoryHtmlReportRendererSpec extends AbstractInventoryReportRendererSpec {
+
+    def "check the correct generation of html"() {
+        def renderer = new InventoryHtmlReportRenderer(outputFile.name, "name", overrides)
+
+        when:
+        renderer.render(projectData)
+
+        then:
+        outputFile.exists()
+        outputFile.text.stripIndent().contains("""<h2>Apache License, Version 2.0</h2>
+<div class='dependency'>
+<p><strong> 1.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod1 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
+<div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
+<label>Manifest License</label>
+<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<label>POM Project URL</label>
+<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
+<label>POM License</label>
+<div class='dependency-value'>Apache License, Version 2.0 - <a href='https://www.apache.org/licenses/LICENSE-2.0'>https://www.apache.org/licenses/LICENSE-2.0</a></div>
+  - Embedded license files:
+    - apache2.license</div>
+<div class='dependency'>
+<p><strong> 2.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod2 <strong>Version:</strong> 0.0.1 </p><label>Project URL</label>
+<div class='dependency-value'><a href='https://projecturl'>https://projecturl</a></div>
+<label>License URL</label>
+<div class='dependency-value'><a href='http://www.apache.org/licenses/LICENSE-2.0.txt'>Apache License, Version 2.0</a></div>""")
+        outputFile.text.stripIndent().contains("""<h2>Unknown</h2>
+<div class='dependency'>
+<p><strong> 3.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod3 <strong>Version:</strong> 0.0.1 </p><label>POM Project URL</label>""")
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.render
+
+class InventoryMarkdownReportRendererSpec extends AbstractInventoryReportRendererSpec {
+
+    def "check the correct generation of markdown"() {
+        def renderer = new InventoryMarkdownReportRenderer(outputFile.name, "name", overrides)
+
+        when:
+        renderer.render(projectData)
+
+        then:
+        outputFile.exists()
+        outputFile.text.replaceAll("\\s+", " ").contains("""## Apache License, Version 2.0
+  
+ **1** **Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1`
+ > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+ > - **Manifest License**: Apache 2.0 (Not Packaged)
+ > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+ > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+   - Embedded license files:
+     - apache2.license
+ **2** **Group:** `dummy-group` **Name:** `mod2` **Version:** `0.0.1`
+ > - **Project URL**: [https://projecturl](https://projecturl)
+ > - **License URL**: [http://www.apache.org/licenses/LICENSE-2.0.txt](Apache License, Version 2.0)
+  
+ ## Unknown
+  
+ **3** **Group:** `dummy-group` **Name:** `mod3` **Version:** `0.0.1`
+ > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+ > - **POM License**: Unknown""".replaceAll("\\s+", " "))
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
@@ -19,29 +19,11 @@ class InventoryMarkdownReportRendererSpec extends AbstractInventoryReportRendere
 
     def "check the correct generation of markdown"() {
         def renderer = new InventoryMarkdownReportRenderer(outputFile.name, "name", overrides)
-
         when:
         renderer.render(projectData)
-
         then:
         outputFile.exists()
-        outputFile.text.replaceAll("\\s+", " ").contains("""## Apache License, Version 2.0
-  
- **1** **Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1`
- > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
- > - **Manifest License**: Apache 2.0 (Not Packaged)
- > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
- > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
-   - Embedded license files:
-     - apache2.license
- **2** **Group:** `dummy-group` **Name:** `mod2` **Version:** `0.0.1`
- > - **Project URL**: [https://projecturl](https://projecturl)
- > - **License URL**: [http://www.apache.org/licenses/LICENSE-2.0.txt](Apache License, Version 2.0)
-  
- ## Unknown
-  
- **3** **Group:** `dummy-group` **Name:** `mod3` **Version:** `0.0.1`
- > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
- > - **POM License**: Unknown""".replaceAll("\\s+", " "))
+        def sanitizedOutput = outputFile.text.replaceAll("_[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z0-9-]+_", "DATE")
+        snapshotter.assertThat(sanitizedOutput).matchesSnapshot()
     }
 }

--- a/src/test/resources/com/github/jk1/license/render/InventoryHtmlReportRendererSpec/check_the_correct_generation_of_html.txt
+++ b/src/test/resources/com/github/jk1/license/render/InventoryHtmlReportRendererSpec/check_the_correct_generation_of_html.txt
@@ -1,0 +1,214 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Dependency License Report for name</title>
+    <meta charset="utf-8">
+    <style>
+    @media print {
+        .inventory {
+            display: none;
+        }
+
+        .content {
+            position: static !important;
+        }
+    }
+
+    html, body, section {
+      height: 100%;
+    }
+
+    body {
+      font-family: sans-serif;
+      line-height: 125%;
+      margin: 0;
+      background: #eee;
+    }
+
+    .header {
+        /* #22aa44 */
+        background: #ff5588;
+        color: white;
+        padding: 2em 1em 1em 1em;
+    }
+
+    .header h1 {
+        font-size: 16pt;
+        margin: 0.5em 0;
+    }
+
+    .header h2 {
+        font-size: 10pt;
+        margin: 0;
+    }
+
+    .container {
+    }
+
+    .inventory {
+        background: #292e34;
+        color: #ddd;
+        padding: 0;
+        position: fixed;
+        left: 0;
+        top: 0;
+        height: 100%;
+        width: 20em;
+        overflow: auto;
+    }
+
+    .inventory ul {
+        margin: 0;
+        padding: 0;
+    }
+
+    .inventory li {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    .inventory li a {
+        width: 100%;
+        box-sizing: border-box;
+        color: #ddd;
+        text-decoration: none;
+        display: flex;
+        flex-direction: row;
+        padding: 15px 12px;
+    }
+
+    .inventory li a:hover {
+        background: #383f45;
+        color: white;
+    }
+
+    .license .name {
+        flex-grow: 1;
+
+    }
+
+    .license .badge {
+        background: #ff5588;
+        padding: 10px 15px;
+        border-radius: 20px;
+        color: white;
+    }
+
+    .content {
+        padding: 1rem;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 20em;
+    }
+
+    .dependency {
+        background: white;
+        padding: 1em;
+        margin-bottom: 1em;
+    }
+
+    .dependency label {
+        font-weight: bold;
+    }
+
+    .dependency-value {
+    }
+    </style>
+</head>
+<body>
+<div class="container">
+<div class='inventory'>
+<div class='header'>
+<h1>my-project </h1>
+<h2>Dependency License Report</h2>
+<h2 class='timestamp'>DATE.</h2></div>
+<h3>name</h3>
+<ul>
+<li><a class='license' href='#name_Apache_License,_Version_2.0'><span class='name'>Apache License, Version 2.0</span> <span class='badge'>3</span></a></li>
+<li><a class='license' href='#name_MIT_License'><span class='name'>MIT License</span> <span class='badge'>1</span></a></li>
+<li><a class='license' href='#name_Unknown'><span class='name'>Unknown</span> <span class='badge'>1</span></a></li>
+</ul>
+<h3>bundle1</h3>
+<ul>
+<li><a class='license' href='#bundle1_Apache__2'><span class='name'>Apache  2</span> <span class='badge'>2</span></a></li>
+</ul>
+</div>
+<div class='content'>
+<h1>name</h1>
+<a id='name_Apache_License,_Version_2.0'></a>
+<h2>Apache License, Version 2.0</h2>
+<div class='dependency'>
+<p><strong> 1.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod1 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
+<div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
+<label>Manifest License</label>
+<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<label>POM Project URL</label>
+<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
+<label>POM License</label>
+<div class='dependency-value'>Apache License, Version 2.0 - <a href='https://www.apache.org/licenses/LICENSE-2.0'>https://www.apache.org/licenses/LICENSE-2.0</a></div>
+<label>Embedded license files</label>
+<div class='dependency-value'><a href='apache2.license'>apache2.license</a></div>
+</div>
+<div class='dependency'>
+<p><strong> 2.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod2 <strong>Version:</strong> 0.0.1 </p><label>Project URL</label>
+<div class='dependency-value'><a href='https://projecturl'>https://projecturl</a></div>
+<label>License URL</label>
+<div class='dependency-value'><a href='http://www.apache.org/licenses/LICENSE-2.0.txt'>Apache License, Version 2.0</a></div>
+</div>
+<div class='dependency'>
+<p><strong> 3.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod4 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
+<div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
+<label>Manifest License</label>
+<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<label>POM Project URL</label>
+<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
+<label>POM License</label>
+<div class='dependency-value'>Apache License, Version 2.0 - <a href='https://www.apache.org/licenses/LICENSE-2.0'>https://www.apache.org/licenses/LICENSE-2.0</a></div>
+<label>Embedded license files</label>
+<div class='dependency-value'><a href='apache2.license'>apache2.license</a></div>
+</div>
+<a id='name_MIT_License'></a>
+<h2>MIT License</h2>
+<div class='dependency'>
+<p><strong> 4.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod4 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
+<div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
+<label>Manifest License</label>
+<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<label>POM Project URL</label>
+<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
+<label>POM License</label>
+<div class='dependency-value'>Apache License, Version 2.0 - <a href='https://www.apache.org/licenses/LICENSE-2.0'>https://www.apache.org/licenses/LICENSE-2.0</a></div>
+<label>Embedded license files</label>
+<div class='dependency-value'><a href='apache2.license'>apache2.license</a></div>
+</div>
+<a id='name_Unknown'></a>
+<h2>Unknown</h2>
+<div class='dependency'>
+<p><strong> 5.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod3 <strong>Version:</strong> 0.0.1 </p><label>POM Project URL</label>
+<div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
+<label>POM License</label>
+<div class='dependency-value'>Unknown</div>
+</div>
+<h1>bundle1</h1>
+<a id='bundle1_Apache__2'></a>
+<h2>Apache  2</h2>
+<div class='dependency'>
+<p><strong>6. mod1 vsome-version</strong></p><label>Project URL</label>
+<div class='dependency-value'><a href='some-projectUrl'>some-projectUrl</a></div>
+<label>License URL</label>
+<div class='dependency-value'><a href='apache-url'>Apache  2</a></div>
+</div>
+<div class='dependency'>
+<p><strong>7. mod2 vsome-version</strong></p><label>Project URL</label>
+<div class='dependency-value'><a href='some-projectUrl'>some-projectUrl</a></div>
+<label>License URL</label>
+<div class='dependency-value'><a href='apache-url'>Apache  2</a></div>
+</div>
+</div>
+
+</div>
+</body>
+</html>

--- a/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown.txt
+++ b/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown.txt
@@ -1,0 +1,57 @@
+
+# name
+## Dependency License Report
+DATE
+## Apache License, Version 2.0
+
+**1** **Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+**2** **Group:** `dummy-group` **Name:** `mod2` **Version:** `0.0.1` 
+> - **Project URL**: [https://projecturl](https://projecturl)
+> - **License URL**: [http://www.apache.org/licenses/LICENSE-2.0.txt](Apache License, Version 2.0)
+
+**3** **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+## MIT License
+
+**4** **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+## Unknown
+
+**5** **Group:** `dummy-group` **Name:** `mod3` **Version:** `0.0.1` 
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Unknown
+
+## bundle1
+
+
+
+
+6. **mod1 vsome-version**
+> - **Project URL**: [some-projectUrl](some-projectUrl)
+> - **License URL**: [apache-url](Apache  2)
+
+
+
+
+7. **mod2 vsome-version**
+> - **Project URL**: [some-projectUrl](some-projectUrl)
+> - **License URL**: [apache-url](Apache  2)
+
+
+

--- a/src/test/resources/com/github/jk1/license/render/JsonReportRendererSpec/writes_a_multi_license_per_module_json.txt
+++ b/src/test/resources/com/github/jk1/license/render/JsonReportRendererSpec/writes_a_multi_license_per_module_json.txt
@@ -1,0 +1,110 @@
+{
+    "dependencies": [
+        {
+            "moduleName": "dummy-group:mod1",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-mani-url",
+                "http://dummy-pom-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache 2.0",
+                    "moduleLicenseUrl": null
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            ]
+        },
+        {
+            "moduleName": "dummy-group:mod2",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-pom-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Unknown",
+                    "moduleLicenseUrl": null
+                }
+            ]
+        },
+        {
+            "moduleName": "dummy-group:mod3",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-pom-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Unknown",
+                    "moduleLicenseUrl": null
+                }
+            ]
+        },
+        {
+            "moduleName": "dummy-group:mod4",
+            "moduleVersion": "0.0.1",
+            "moduleUrls": [
+                "http://dummy-mani-url",
+                "http://dummy-pom-project-url"
+            ],
+            "moduleLicenses": [
+                {
+                    "moduleLicense": "Apache 2.0",
+                    "moduleLicenseUrl": null
+                },
+                {
+                    "moduleLicense": "Apache License, Version 2.0",
+                    "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+                },
+                {
+                    "moduleLicense": "MIT License",
+                    "moduleLicenseUrl": "https://opensource.org/licenses/MIT"
+                }
+            ]
+        }
+    ],
+    "importedModules": [
+        {
+            "moduleName": "bundle1",
+            "dependencies": [
+                {
+                    "moduleName": "mod1",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                },
+                {
+                    "moduleName": "mod2",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                }
+            ]
+        },
+        {
+            "moduleName": "bundle1",
+            "dependencies": [
+                {
+                    "moduleName": "mod1",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                },
+                {
+                    "moduleName": "mod2",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                }
+            ]
+        }
+    ]
+}

--- a/src/test/resources/com/github/jk1/license/render/JsonReportRendererSpec/writes_a_one_license_per_module_json.txt
+++ b/src/test/resources/com/github/jk1/license/render/JsonReportRendererSpec/writes_a_one_license_per_module_json.txt
@@ -1,0 +1,70 @@
+{
+    "dependencies": [
+        {
+            "moduleName": "dummy-group:mod1",
+            "moduleUrl": "http://dummy-pom-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "Apache License, Version 2.0",
+            "moduleLicenseUrl": "https://www.apache.org/licenses/LICENSE-2.0"
+        },
+        {
+            "moduleName": "dummy-group:mod2",
+            "moduleUrl": "http://dummy-pom-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "Unknown"
+        },
+        {
+            "moduleName": "dummy-group:mod3",
+            "moduleUrl": "http://dummy-pom-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "Unknown"
+        },
+        {
+            "moduleName": "dummy-group:mod4",
+            "moduleUrl": "http://dummy-pom-project-url",
+            "moduleVersion": "0.0.1",
+            "moduleLicense": "MIT License",
+            "moduleLicenseUrl": "https://opensource.org/licenses/MIT"
+        }
+    ],
+    "importedModules": [
+        {
+            "moduleName": "bundle1",
+            "dependencies": [
+                {
+                    "moduleName": "mod1",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                },
+                {
+                    "moduleName": "mod2",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                }
+            ]
+        },
+        {
+            "moduleName": "bundle1",
+            "dependencies": [
+                {
+                    "moduleName": "mod1",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                },
+                {
+                    "moduleName": "mod2",
+                    "moduleUrl": "some-projectUrl",
+                    "moduleVersion": "some-version",
+                    "moduleLicense": "Apache  2",
+                    "moduleLicenseUrl": "apache-url"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
After introducing the delayed loading of the overrides file with PR #286, the overrides for the first dependency in the InventoryReportRenderer were not applied.

It is not entirely clear to me, why this happens. I just assume it has to do with groovy-magic related to automatically calling the getters of properties.

To resolve this, the base-property was renamed, so it doesn't conflict with the getter.

For writing the tests, I updated to spock 2.4 because it has the [Snapshot-Testing Feature](https://spockframework.org/spock/docs/2.4-SNAPSHOT/all_in_one.html#snapshot-testing). I implemented it like this: when executing it locally, the tests will always become green but may update the snapshot-files. When running in the CI the tests will become red if the snapshot changed. I think it is an OK solution because the snapshot-files are checked into git anyways and even if the tests locally won't fail, a developer will see that things changed. 

 Also I updated the github actions because their version were mentioned to be deprecated.