### PR TITLE
Remove debug println from ExtendedJsonReportRenderer

### DIFF
--- a/src/main/groovy/com/github/jk1/license/render/ExtendedJsonReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/ExtendedJsonReportRenderer.groovy
@@ -136,7 +136,6 @@ class ExtendedJsonReportRenderer implements ReportRenderer {
                     licenseFile.fileDetails.file.collect({ new File("$config.absoluteOutputDir/$it").text })
                 })
 
-            println(embeddedLicensesList)
             trimAndRemoveNullEntries([moduleName      : moduleName,
                                       moduleUrl       : moduleUrl,
                                       moduleVersion   : moduleVersion,


### PR DESCRIPTION
There is a debug session leftover `println` in ExtendedJsonReportRenderer. The author says that this println statement was not intended to be used in production, it just slipped through review. The logging always renders the full text of all licenses every time  `generateLicenseReport` task runs, which makes it very noisy.