### PR TITLE
Make markdown reporter more diff friendly

### DIFF
--- a/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
@@ -24,9 +24,14 @@ import com.github.jk1.license.PomData
 import com.github.jk1.license.ProjectData
 
 class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
+    private Boolean includeTimestamp
+    private Boolean includeCounter
 
-    InventoryMarkdownReportRenderer(String fileName = 'licenses.md', String name = null, File overridesFile = null) {
+    InventoryMarkdownReportRenderer(String fileName = 'licenses.md', String name = null, File overridesFile = null,
+                                    Boolean includeTimestamp = true, Boolean includeCounter = true) {
         super(fileName, name, overridesFile)
+        this.includeTimestamp = includeTimestamp
+        this.includeCounter = includeCounter
     }
 
     @Override
@@ -68,7 +73,7 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
         output << "\n"
         output << "# ${name}\n"
         output << "## Dependency License Report\n"
-        output << "_${new Date().format('yyyy-MM-dd HH:mm:ss z')}_\n"
+        if (includeTimestamp) output << "_${new Date().format('yyyy-MM-dd HH:mm:ss z')}_\n"
     }
 
     protected void printDependency(ModuleData data) {
@@ -109,7 +114,7 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
     }
 
     protected void printDependencyMetaInformation(ModuleData data) {
-        output << "**${++counter}** "
+        if (includeCounter) output << "**${++counter}** "
         if (data.group) output << "**Group:** `$data.group` "
         if (data.name) output << "**Name:** `$data.name` "
         if (data.version) output << "**Version:** `$data.version` "
@@ -154,7 +159,8 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
 
     protected printImportedDependency(ImportedModuleData data) {
         output << "\n\n"
-        output << "${++counter}. **${data.name} v${data.version}**\n"
+        if (includeCounter) output << "${++counter}. "
+        output << "**${data.name} v${data.version}**\n"
         output << sectionLink("Project URL", data.projectUrl, data.projectUrl)
         output << sectionLink("License URL", data.license, data.licenseUrl)
         output << "\n\n"

--- a/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec.groovy
@@ -26,4 +26,13 @@ class InventoryMarkdownReportRendererSpec extends AbstractInventoryReportRendere
         def sanitizedOutput = outputFile.text.replaceAll("_[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z0-9-]+_", "DATE")
         snapshotter.assertThat(sanitizedOutput).matchesSnapshot()
     }
+
+    def "check the correct generation of markdown without timestamp and counter"() {
+        def renderer = new InventoryMarkdownReportRenderer(outputFile.name, "name", overrides, false, false)
+        when:
+        renderer.render(projectData)
+        then:
+        outputFile.exists()
+        snapshotter.assertThat(outputFile.text).matchesSnapshot()
+    }
 }

--- a/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown_without_timestamp_and_counter.txt
+++ b/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown_without_timestamp_and_counter.txt
@@ -1,0 +1,56 @@
+
+# name
+## Dependency License Report
+## Apache License, Version 2.0
+
+**Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+**Group:** `dummy-group` **Name:** `mod2` **Version:** `0.0.1` 
+> - **Project URL**: [https://projecturl](https://projecturl)
+> - **License URL**: [http://www.apache.org/licenses/LICENSE-2.0.txt](Apache License, Version 2.0)
+
+**Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+## MIT License
+
+**Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
+> - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
+> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+> - **Embedded license files**: [apache2.license](apache2.license)
+
+## Unknown
+
+**Group:** `dummy-group` **Name:** `mod3` **Version:** `0.0.1` 
+> - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
+> - **POM License**: Unknown
+
+## bundle1
+
+
+
+
+**mod1 vsome-version**
+> - **Project URL**: [some-projectUrl](some-projectUrl)
+> - **License URL**: [apache-url](Apache  2)
+
+
+
+
+**mod2 vsome-version**
+> - **Project URL**: [some-projectUrl](some-projectUrl)
+> - **License URL**: [apache-url](Apache  2)
+
+
+


### PR DESCRIPTION
The markdown report is a convenient because it is nice to read when rendered to html but its source is also nice to read when compared to html report, for example. The markdown report can also be added to version control in order to track and verify changes to licenses.

However, the timestamp and counter values included in the report make it unfriendly for diffing. For example, adding or removing a dependency may cause tens or hundred of modified lines in a diff.

I propose we make it configurable if timetamp or counter values should be included in the report. This is what I have implemented in this pull request. The change should be backwards compatible because the default values are such that the timestamp and counter values are included in the report.