### PR TITLE
Track allowedLicensesFile as task input file

### DIFF
--- a/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/CheckLicenseTask.groovy
@@ -45,7 +45,8 @@ class CheckLicenseTask extends DefaultTask {
     @Nested
     LicenseReportExtension config
 
-    @Input
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     Object getAllowedLicenseFile() {
         return config.allowedLicensesFile
     }


### PR DESCRIPTION
Use `@InputFile` rather than `@Input` so that we track file contents, not just the path. This fixes up-to-date checking and build caching for the checkLicense task when the contents of the allowed license file changes.

Also, use RELATIVE_PATH sensitivity instead of the default ABSOLUTE for a bit more flexibility in how this path is evaluated.