### PR TITLE
fix: align normalizer rules between SPDX+default; fixing minor attribution issues

### DIFF
--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -34,6 +34,7 @@
     { "bundleName" : "LGPL-2.1-only", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1" },
     { "bundleName" : "LGPL-3.0-only", "licenseName" : "GNU LESSER GENERAL PUBLIC LICENSE, Version 3", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0" },
     { "bundleName" : "MIT", "licenseName" : "MIT License", "licenseUrl" : "https://opensource.org/licenses/MIT" },
+    { "bundleName" : "MIT-0", "licenseName" : "MIT No Attribution License", "licenseUrl" : "https://opensource.org/license/mit-0" },
     { "bundleName" : "MPL-1.1", "licenseName" : "Mozilla Public License Version 1.1", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/1.1" },
     { "bundleName" : "MPL-2.0", "licenseName" : "Mozilla Public License, Version 2.0", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/2.0" },
     { "bundleName" : "Public-Domain", "licenseName" : "PUBLIC DOMAIN", "licenseUrl" : "" }
@@ -94,6 +95,7 @@
     { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?gnu\\.org/licenses(/old-licenses)?/lgpl(-3)?(\\.(html|txt))?" },
     { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\slicen[cs]e)?(\\s\\(MIT\\))?" },
     { "bundleName" : "MIT", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MIT(\\.php)?" },
+    { "bundleName" : "MIT-0", "licenseNamePattern" : "(The\\s)?MIT No Attribution(\\slicen[cs]e)?(\\s\\(MIT[-]?0\\))?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MPL-2\\.0" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/MPL/2\\.0/" },

--- a/src/main/resources/spdx-license-normalizer-bundle.json
+++ b/src/main/resources/spdx-license-normalizer-bundle.json
@@ -33,7 +33,8 @@
     { "bundleName" : "GPL-3.0-only", "licenseName" : "GPL-3.0-only", "licenseUrl" : "https://www.gnu.org/licenses/gpl-3.0" },
     { "bundleName" : "LGPL-2.1-only", "licenseName" : "LGPL-2.1-only", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-2.1" },
     { "bundleName" : "LGPL-3.0-only", "licenseName" : "LGPL-3.0-only", "licenseUrl" : "https://www.gnu.org/licenses/lgpl-3.0" },
-    { "bundleName" : "MIT", "licenseName" : "MIT", "licenseUrl" : "https://opensource.org/licenses/MIT" },
+    { "bundleName" : "MIT", "licenseName" : "MIT", "licenseUrl" : "https://opensource.org/licenses/mit" },
+    { "bundleName" : "MIT-0", "licenseName" : "MIT-0", "licenseUrl" : "https://opensource.org/license/mit-0" },
     { "bundleName" : "MPL-1.1", "licenseName" : "MPL-1.1", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/1.1" },
     { "bundleName" : "MPL-2.0", "licenseName" : "MPL-2.0", "licenseUrl" : "https://www.mozilla.org/en-US/MPL/2.0" }
   ],
@@ -93,6 +94,7 @@
     { "bundleName" : "LGPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?gnu\\.org/licenses(/old-licenses)?/lgpl(-3)?(\\.(html|txt))?" },
     { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\slicen[cs]e)?(\\s\\(MIT\\))?" },
     { "bundleName" : "MIT", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MIT(\\.php)?" },
+    { "bundleName" : "MIT-0", "licenseNamePattern" : "(The\\s)?MIT No Attribution(\\slicen[cs]e)?(\\s\\(MIT[-]?0\\))?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MPL-2\\.0" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/MPL/2\\.0/" }


### PR DESCRIPTION
This does a few clean-ups for correctness to the normalizer rules

- synchronises regexes/rules between the two bundles
  - this mainly fixes some regex style to prefer character classes to `(x|a)` groups and do it consistently. 
  - makes normalizing of EDL > BSD-3-Clause consistent as originally done in #336 
  - Correct Apache 1.0 to be matched separately to Apache 1.1 in both bundles. These are two different licenses, with two different SPDX IDs, differing in attribution requirements.
- removes a couple of duplicate/unnecessary regexes where a looser match has been later added as a new rule
- removes `Public-Domain` from SPDX normalizer. This is [not an SPDX ID](https://spdx.org/licenses/), so this is wrong/misleading. We need proper rules for various "public domain" variants IMHO as you will see there are lots of public domain variants. independent of the true "public domain" meaning.
- removes `Creative Commons` from matching `Public Domain` in the `default` ruleset. I cant find why this was added, but this is really not correct. There are multiple Public Domain CC (and non-CC) licenses, and many other licenses with and without attribution within CC but this regex is extremely broad. Arguably the other rules should be removed too since they are overly broad on content, but have left here for now.
- Use non-deprecated SPDX IDs for `GPL-2.0-only WITH Classpath-Exception-2.0`. `GPL-2.0` and such are deprecated. Matching rules are unchanged