### PR TITLE
fix: make dependency cache key deterministic

### DIFF
--- a/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
@@ -44,12 +44,15 @@ class ReportTask extends DefaultTask {
     }
 
     @Input
-    String[] getClasspath() {
+    String[] getResolvedDependencies() {
         def reader = new ProjectReader(config)
-        // take configurations' shallow snapshot but don't revolve them
+        // Use resolved dependencies (including transitives) for cache key to ensure
+        // the cache is invalidated when any dependency changes, not just declared ones.
         def deps = getConfig().projects
                 .collectMany { reader.read(it).allDependencies }
-                .collect { it.name + it.group + it.version}
+                .collect { "${it.group}:${it.name}:${it.version}" }
+                .unique()
+                .sort()
         deps
     }
 

--- a/src/test/groovy/com/github/jk1/license/ReportTaskCachingSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/ReportTaskCachingSpec.groovy
@@ -117,6 +117,45 @@ class ReportTaskCachingSpec extends Specification {
 
     }
 
+    def "should invalidate cache when transitive dependency version changes"() {
+        setup:
+        buildFile.text = """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation "junit:junit:4.12"
+            }
+            configurations.all {
+                resolutionStrategy {
+                    force "org.hamcrest:hamcrest-core:\${project.ext.hamcrestVersion}"
+                }
+            }
+        """
+
+        when:
+        BuildResult result = runBuildWith('--build-cache', "generateLicenseReport", "-PhamcrestVersion=1.3")
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runBuildWith('--build-cache', "clean", "generateLicenseReport", "-PhamcrestVersion=1.3")
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        result = runBuildWith('--build-cache', "clean", "generateLicenseReport", "-PhamcrestVersion=1.1")
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.SUCCESS
+    }
+
     @PendingFeature(reason = "task output caching not working correctly when filteres are changed")
     def "should cache task outputs for filter"() {
         when:


### PR DESCRIPTION
ReportTask could produce inconsistent cache keys for the same set of
dependencies because the key was neither deduplicated nor sorted. This
could cause both unnecessary cache misses and stale cache hits.

Fix that by adding .unique() and .sort() to the resolved dependency
list, and normalize the key format to "group:name:version". Also rename
getClasspath() to getResolvedDependencies() to better reflect its
purpose, and add a test verifying that transitive dependency changes
correctly invalidate the cache.

Fixes #327