### PR TITLE
build(deps): bump gradle to 8.14.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/groovy/com/github/jk1/license/GradleTestVersion.groovy
+++ b/src/test/groovy/com/github/jk1/license/GradleTestVersion.groovy
@@ -27,7 +27,7 @@ class GradleTestVersion {
      */
     final static def supportedVersions = [
             new GradleTestVersion(version: '7.6.6',  minJdk: 8,  maxJdk: 19),
-            new GradleTestVersion(version: '8.14.4', minJdk: 8,  maxJdk: 24),
+            new GradleTestVersion(version: '8.14.5', minJdk: 8,  maxJdk: 25),
             new GradleTestVersion(version: '9.5.0',  minJdk: 17, maxJdk: 26),
     ]
 


### PR DESCRIPTION
Also allow testing with Java 25, which might work sufficiently after https://github.com/gradle/gradle/issues/36420