### PR TITLE
fix: support multiple license URLs from OSGi manifest data

### DIFF
--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -46,7 +46,7 @@ class ProjectData {
     Set<ConfigurationData> configurations = new TreeSet<ConfigurationData>()
     List<ImportedModuleBundle> importedModules = new ArrayList<ImportedModuleBundle>()
     Set<ModuleData> getAllDependencies() {
-        new TreeSet<ModuleData>(configurations*.dependencies.flatten())
+        new TreeSet<ModuleData>(configurations*.dependencies.flatten() as List<ModuleData>)
     }
 }
 
@@ -69,11 +69,17 @@ class ModuleData {
     boolean isEmpty() { manifests.isEmpty() && poms.isEmpty() && licenseFiles.isEmpty() }
 }
 
-@Sortable
+@Sortable(includes = ["name", "version"])
 @Canonical
 class ManifestData {
-    String name, version, description, vendor, url, license, licenseUrl
+    String name, version, description, vendor, url
+    Set<License> licenses = new TreeSet<License>()
     boolean hasPackagedLicense
+
+    /** @deprecated Since 3.1.0, for removal. Use {@link #licenses} instead. Returns the name of the first license for backward compatibility. */
+    @Deprecated String getLicense() { licenses.find { true }?.name }
+    /** @deprecated Since 3.1.0, for removal. Use {@link #licenses} instead. Returns the URL of the first license for backward compatibility. */
+    @Deprecated String getLicenseUrl() { licenses.find { true }?.url }
 }
 
 @Canonical

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -20,7 +20,6 @@ import com.github.jk1.license.ImportedModuleData
 import com.github.jk1.license.License
 import com.github.jk1.license.LicenseFileDetails
 import com.github.jk1.license.LicenseReportExtension
-import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.ProjectData
 import com.github.jk1.license.task.ReportTask
@@ -110,11 +109,11 @@ class LicenseBundleNormalizer implements DependencyFilter {
         List<NormalizerTransformationRuleMatcher> transformationRuleMatchers = makeNormalizerTransformationRuleMatchers(normalizerConfig.transformationRules)
 
         LOGGER.debug("Normalizing pom.xml license section...")
-        data.configurations*.dependencies.flatten().forEach { normalizePoms(transformationRuleMatchers, it) }
+        data.configurations*.dependencies.flatten().forEach { ModuleData it -> normalizePoms(transformationRuleMatchers, it) }
         LOGGER.debug("Normalizing JAR manifest licenses...")
-        data.configurations*.dependencies.flatten().forEach { normalizeManifest(transformationRuleMatchers, it) }
+        data.configurations*.dependencies.flatten().forEach { ModuleData it -> normalizeManifest(transformationRuleMatchers, it) }
         LOGGER.debug("Normalizing embedded license files...")
-        data.configurations*.dependencies.flatten().forEach { normalizeLicenseFileDetails(transformationRuleMatchers, it) }
+        data.configurations*.dependencies.flatten().forEach { ModuleData it -> normalizeLicenseFileDetails(transformationRuleMatchers, it) }
         data.importedModules.forEach { normalizeImportedModuleBundle(transformationRuleMatchers, it) }
         LOGGER.debug("Modules normalized, removing duplicates...")
         data = duplicateFilter.filter(data)
@@ -168,19 +167,25 @@ class LicenseBundleNormalizer implements DependencyFilter {
         String module = dependency.group + ':' + dependency.name + ':' + dependency.version
         LOGGER.debug("Checking module {} (normalize pom)", module)
         dependency.poms.forEach { pom ->
-            List<License> normalizedLicense = pom.licenses.collectMany { normalizePomLicense(transformationRuleMatchers, it, module) }
+            List<License> normalizedLicense = pom.licenses.collectMany { normalizeLicense(transformationRuleMatchers, it, module) }
             pom.licenses.clear()
             pom.licenses.addAll(normalizedLicense)
         }
     }
+
     protected def normalizeManifest(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                   ModuleData dependency) {
         String module = dependency.group + ':' + dependency.name + ':' + dependency.version
         LOGGER.debug("Checking module {} (normalize manifest)", module)
-        List<ManifestData> normalizedManifests = dependency.manifests.collectMany {normalizeManifestLicense(transformationRuleMatchers, it, module) }
-        dependency.manifests.clear()
-        dependency.manifests.addAll(normalizedManifests)
+        dependency.manifests.forEach { manifest ->
+            List<License> normalizedLicenses = manifest.licenses.collectMany {
+                normalizeLicense(transformationRuleMatchers, it, module)
+            }
+            manifest.licenses.clear()
+            manifest.licenses.addAll(normalizedLicenses)
+        }
     }
+
     protected def normalizeLicenseFileDetails(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
                                             ModuleData dependency) {
         String module = dependency.group + ':' + dependency.name + ':' + dependency.version
@@ -199,9 +204,9 @@ class LicenseBundleNormalizer implements DependencyFilter {
         importedModuleBundle.modules.addAll(normalizedModuleData)
     }
 
-    protected Collection<License> normalizePomLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
-                                                    License license,
-                                                    String module) {
+    protected Collection<License> normalizeLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
+                                                   License license,
+                                                   String module) {
         List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
                 module, license.name, license.url, {null})
 
@@ -209,23 +214,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
 
         if (rules.isEmpty()) return [license]
 
-        rules.collect { normalizeSinglePomLicense(it, license) }
-    }
-
-    protected Collection<ManifestData> normalizeManifestLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
-                                                              ManifestData manifest,
-                                                              String module) {
-        List<NormalizerTransformationRule> rules = transformationRulesFor(transformationRuleMatchers,
-                module, manifest.license, manifest.licenseUrl, {null})
-
-        LOGGER.debug("License {} ({}) (via manifest data, module {}) matches the following rules: [{}]",
-                manifest.name, manifest.url,
-                module,
-                rules.join(","))
-
-        if (rules.isEmpty()) return [manifest]
-
-        rules.collect { normalizeSingleManifestLicense(it, manifest) }
+        rules.collect { normalizeSingleLicense(it, license) }
     }
 
     protected Collection<LicenseFileDetails> normalizeLicenseFileDetailsLicense(List<NormalizerTransformationRuleMatcher> transformationRuleMatchers,
@@ -270,7 +259,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
     }
 
     @CompileStatic
-    protected License normalizeSinglePomLicense(NormalizerTransformationRule rule, License license) {
+    protected License normalizeSingleLicense(NormalizerTransformationRule rule, License license) {
         License normalized = new License(
             name: license.name,
             url:  license.url
@@ -279,28 +268,6 @@ class LicenseBundleNormalizer implements DependencyFilter {
         normalizeWithBundle(rule) { NormalizerLicenseBundle bundle ->
             if (rule.transformName) normalized.name = bundle.licenseName
             if (rule.transformUrl) normalized.url = bundle.licenseUrl
-        }
-        normalized
-    }
-
-    @CompileStatic
-    protected ManifestData normalizeSingleManifestLicense(NormalizerTransformationRule rule, ManifestData manifest) {
-        ManifestData normalized = new ManifestData(
-            name: manifest.name,
-            version: manifest.version,
-            description: manifest.description,
-            vendor: manifest.vendor,
-            license: manifest.license,
-            licenseUrl: manifest.licenseUrl,
-            url: manifest.url,
-            hasPackagedLicense: manifest.hasPackagedLicense
-        )
-
-        normalizeWithBundle(rule) { NormalizerLicenseBundle bundle ->
-            if (rule.transformName)
-                normalized.license = bundle.licenseName
-            if (rule.transformUrl)
-                normalized.licenseUrl = bundle.licenseUrl
         }
         normalized
     }

--- a/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/LicenseFilesReader.groovy
@@ -46,7 +46,7 @@ class LicenseFilesReader {
         switch (fileExtension) {
             case "zip":
             case "jar":
-                Collection<String> files = readLicenseFiles(artifact, new ZipFile(artifact.file, ZipFile.OPEN_READ))
+                Collection<String> files = readLicenseFiles(artifact.file)
                 if (files.isEmpty()) return null
 
                 def data = new LicenseFileData()
@@ -60,32 +60,34 @@ class LicenseFilesReader {
         }
     }
 
-    private Collection<String> readLicenseFiles(ResolvedArtifact artifact, ZipFile zipFile) {
-        Set<String> licenseFileBaseNames = [
-                "license",
-                "readme",
-                "notice",
-                "copying",
-                "copying.lesser",
-                "about"
-        ]
-        Set<ZipEntry> entryNames = zipFile.entries().toList().findAll { ZipEntry entry ->
-            String name = entry.getName()
-            String baseName = substringAfterLast(name, "/") ?: name
-            String fileExtension = Files.getExtension(baseName)
-            if (fileExtension?.equalsIgnoreCase("class")) return null // Skip class files
-            if (fileExtension) baseName -= ".$fileExtension"
-            return licenseFileBaseNames.find { it.equalsIgnoreCase(baseName) }
-        }
-        if (!entryNames) return Collections.emptyList()
-        return entryNames.collect { ZipEntry entry ->
-            String entryName = entry.name
-            if (!entryName.startsWith("/")) entryName = "/$entryName"
-            String path = "${artifact.file.name}${entryName}"
-            File file = new File(config.absoluteOutputDir, path)
-            file.parentFile.mkdirs()
-            file.text = zipFile.getInputStream(entry).text
-            return path
+    private Collection<String> readLicenseFiles(File file) {
+        try (ZipFile zipFile = new ZipFile(file, ZipFile.OPEN_READ)) {
+            Set<String> licenseFileBaseNames = [
+                    "license",
+                    "readme",
+                    "notice",
+                    "copying",
+                    "copying.lesser",
+                    "about"
+            ]
+            Set<ZipEntry> entryNames = zipFile.entries().toList().findAll { ZipEntry entry ->
+                String name = entry.getName()
+                String baseName = substringAfterLast(name, "/") ?: name
+                String fileExtension = Files.getExtension(baseName)
+                if (fileExtension?.equalsIgnoreCase("class")) return null // Skip class files
+                if (fileExtension) baseName -= ".$fileExtension"
+                return licenseFileBaseNames.find { it.equalsIgnoreCase(baseName) }
+            }
+            if (!entryNames) return Collections.emptyList()
+            return entryNames.collect { ZipEntry entry ->
+                String entryName = entry.name
+                if (!entryName.startsWith("/")) entryName = "/$entryName"
+                String path = "${file.name}${entryName}"
+                File dest = new File(config.absoluteOutputDir, path)
+                dest.parentFile.mkdirs()
+                dest.text = zipFile.getInputStream(entry).text
+                return path
+            }
         }
     }
 

--- a/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ManifestReader.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license.reader
 
+import com.github.jk1.license.License
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ManifestData
 import com.github.jk1.license.task.ReportTask
@@ -56,12 +57,16 @@ class ManifestReader {
                 Manifest mf = lookupManifest(artifact.file)
                 if (mf) {
                     ManifestData data = manifestToData(mf)
-                    def path = findLicenseFile(artifact.file, data.license)
-                    if (path != null){
-                        data.hasPackagedLicense = true
-                        File dest = new File(config.absoluteOutputDir, "${artifact.file.name}/${data.license}.html")
-                        data.url="${artifact.file.name}/${data.license}.html"
-                        writeLicenseFile(artifact.file, path, dest)
+                    data.licenses.each { License license ->
+                        if (!license.name) return
+                        def path = findLicenseFile(artifact.file, license.name)
+                        if (path != null) {
+                            data.hasPackagedLicense = true
+                            String relativeUrl = "${artifact.file.name}/${license.name}.html"
+                            data.licenses.remove(license)
+                            data.licenses << new License(name: license.name, url: relativeUrl)
+                            writeLicenseFile(artifact.file, path, new File(config.absoluteOutputDir, relativeUrl))
+                        }
                     }
                     return data
                 }
@@ -71,11 +76,11 @@ class ManifestReader {
         return null
     }
 
-    private Manifest lookupManifest(File file) {
-        try {
-            return new JarFile(file).manifest
+    private Manifest lookupManifest(File artifactFile) {
+        try (JarFile jarFile = new JarFile(artifactFile)) {
+            return jarFile.manifest
         } catch (Exception e) {
-            LOGGER.info("No manifest found for file: $file", e)
+            LOGGER.info("No manifest found for file: $artifactFile", e)
             return null
         }
     }
@@ -89,29 +94,71 @@ class ManifestReader {
         data.name = attr.getValue('Bundle-Name') ?: attr.getValue('Implementation-Title') ?: attr.getValue('Bundle-SymbolicName')
         data.version = attr.getValue('Bundle-Version') ?: attr.getValue('Implementation-Version') ?: attr.getValue('Specification-Version')
         data.description = attr.getValue('Bundle-Description')
-        String bundleLicense = attr.getValue('Bundle-License')
         data.vendor = attr.getValue('Bundle-Vendor') ?: attr.getValue('Implementation-Vendor')
         data.url = attr.getValue('Bundle-DocURL')
-        if (Files.maybeLicenseUrl(bundleLicense)) {
-			def allLicenseParts = bundleLicense.split(';')
-            data.licenseUrl = allLicenseParts[0]
-			allLicenseParts.each {
-				def additionalParameter = it.split('=')
-
-				if (additionalParameter[0] == 'description')
-					data.license = additionalParameter[1]
-			}
-        }
-        else {
-            data.license = bundleLicense
-        }
+        data.licenses += bundleLicenses(attr.getValue('Bundle-License'))
         LOGGER.info("Returning manifest data: " + data.dump())
         return data
     }
 
-    private String findLicenseFile(File artifactFile, String licenseFileName) {
+    /**
+     * Parses the OSGi `Bundle-License` header, which may contain multiple licenses.
+     *
+     *   Bundle-License ::= '<<EXTERNAL>>' |
+     *                         ( license ( ',' license ) * )
+     *   license        ::= license-identifier ( ';' license-attr ) *
+     *   license-attr   ::= description | link
+     *   description    ::= 'description' '=' string
+     *   link           ::= 'link' '=' <url>
+     */
+    private List<License> bundleLicenses(String bundleLicenseHeader) {
+        if (!bundleLicenseHeader) return []
+
         try {
-            ZipFile file = new ZipFile(artifactFile, ZipFile.OPEN_READ)
+            def licenses = OsgiHeader.parse(bundleLicenseHeader)
+                    .collect { clauseToLicense(it) }
+                    .findAll()
+
+            return licenseDidntParseCleanly(bundleLicenseHeader, licenses)
+                    ? [new License(name: bundleLicenseHeader)]
+                    : licenses
+        } catch (Exception e) {
+            LOGGER.warn("Failed to parse Bundle-License header: $bundleLicenseHeader", e)
+            return []
+        }
+    }
+
+    private static License clauseToLicense(OsgiHeader.Clause clause) {
+        String name = clause.names.find()
+        String link = clause.attributes.link
+        String description = clause.attributes.description
+
+        // only use description as a fallback name
+        def license = new License(name: Files.maybeLicenseUrl(name) ? description : name)
+
+        // Prefer url from any link attribute; else check the name
+        if (Files.maybeLicenseUrl(link)) {
+            license.url = link
+        } else if (Files.maybeLicenseUrl(name)) {
+            license.url = name
+        }
+
+        license.name == null && license.url == null ? null : license
+    }
+
+    /**
+     * If the license header had a comma-space, but none of the licenses appear to represent URLs; conclude
+     * that something is probably not strictly compliant with the spec, and a raw license name value is
+     * probably present. This will fail to parse a header like `Apache-2.0, MIT` as two separate licenses,
+     * so may need to be re-evaluated if this becomes more common. An example license that fails to parse
+     * sensibly from its `Bundle-License` with strict parsing was `org.freemarker:freemarker:2.3.34`.
+     */
+    private static licenseDidntParseCleanly(String bundleLicenseHeader, List<License> licenses) {
+        bundleLicenseHeader.contains(", ") && licenses.every { !it.url }
+    }
+
+    private String findLicenseFile(File artifactFile, String licenseFileName) {
+        try (ZipFile file = new ZipFile(artifactFile, ZipFile.OPEN_READ)) {
             return [
                     "/$licenseFileName",
                     "/META-INF/$licenseFileName",
@@ -128,8 +175,7 @@ class ManifestReader {
     }
 
     private void writeLicenseFile(File artifactFile, String licenseFileName, File destinationFile) {
-        try {
-            ZipFile file = new ZipFile(artifactFile, ZipFile.OPEN_READ)
+        try (ZipFile file = new ZipFile(artifactFile, ZipFile.OPEN_READ)) {
             ZipEntry entry = file.getEntry(licenseFileName)
             destinationFile.parentFile.mkdirs()
             destinationFile.text = file.getInputStream(entry).text

--- a/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ModuleReader.groovy
@@ -50,8 +50,8 @@ class ModuleReaderImpl implements ModuleReader {
         CachingPomResolver pomResolver = new CachingPomResolver(project)
         dependency.moduleArtifacts.each { ResolvedArtifact artifact ->
             LOGGER.info("Processing artifact: $artifact ($artifact.file)")
-            moduleData.hasArtifactFile = artifact.file.exists()
-            if (moduleData.hasArtifactFile) {
+            if (artifact.file.exists()) {
+                moduleData.hasArtifactFile = true
                 def pom = pomReader.withResolver(pomResolver).readPomData(artifact)
                 def manifest = manifestReader.readManifestData(artifact)
                 def licenseFile = filesReader.read(artifact)

--- a/src/main/groovy/com/github/jk1/license/reader/OsgiHeader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/OsgiHeader.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.reader
+
+/**
+ * Parser + serializer for the OSGi "common header syntax" (OSGi Core, ch. 3).
+ *
+ *   header    ::= clause ( ',' clause )*
+ *   clause    ::= name ( ';' name )* ( ';' parameter )*
+ *   parameter ::= key '='  value      // attribute
+ *              |  key ':=' value      // directive
+ *   value     ::= token | '"' quoted '"'
+ *
+ * Multiple names before the parameters ("aliases") share one clause, e.g.
+ *   org.foo;org.bar;version="1.0"
+ * yields a single clause with names [org.foo, org.bar].
+ *
+ * Limitations (intentional, to match the strict spec / Equinox / Felix):
+ *  - No backslash escaping inside quoted values. Standard OSGi has no way to
+ *    represent a literal '"' inside a quoted value; bnd extends the syntax to
+ *    allow it, this parser does not.
+ *  - Surrounding whitespace around names, keys and values is trimmed.
+ *  - Attribute/directive values containing a separator (, ; = :) or whitespace
+ *    MUST be quoted in the input; on output they are re-quoted automatically.
+ *
+ * No external dependencies.
+ */
+class OsgiHeader {
+
+    /** One clause: one or more names sharing a set of attributes and directives. */
+    static class Clause {
+        List<String> names = []
+        Map<String, String> attributes = [:]   // insertion-ordered
+        Map<String, String> directives = [:]
+    }
+
+    /** Quote-aware tokenizer: splits on the given separator chars, ignoring
+     *  separators that fall inside double quotes. Quotes are stripped. */
+    private static class QuotedTokenizer {
+        private final String s
+        private final String seps
+        private int i = 0
+        char separator = 0 as char   // separator that ended the last token (0 = end of input)
+
+        QuotedTokenizer(String s, String seps) { this.s = s; this.seps = seps }
+
+        String next() {
+            def sb = new StringBuilder()
+            while (i < s.length()) {
+                char c = s.charAt(i)
+                if (seps.indexOf((int) c) >= 0) {
+                    separator = c; i++; return sb.toString()
+                }
+                if (c == ('"' as char)) {
+                    i++
+                    while (i < s.length() && s.charAt(i) != ('"' as char)) {
+                        sb.append(s.charAt(i)); i++
+                    }
+                    i++ // skip closing quote
+                    continue
+                }
+                sb.append(c); i++
+            }
+            separator = 0 as char
+            sb.toString()
+        }
+    }
+
+    /** Parse a header value into an ordered list of clauses. */
+    static List<Clause> parse(String header) {
+        def result = []
+        if (!header?.trim()) return result
+
+        def qt = new QuotedTokenizer(header, ';=,')
+        char del
+        while (true) {
+            def clause = new Clause()
+
+            String name = qt.next().trim()
+            del = qt.separator
+            if (name) clause.names << name
+
+            while (del == (';' as char)) {
+                String key = qt.next().trim()
+                del = qt.separator
+                if (del != ('=' as char)) {          // bare token => another name (alias)
+                    if (key) clause.names << key
+                    continue
+                }
+                String value = qt.next().trim()       // del was '=', read the value
+                del = qt.separator
+                if (key.endsWith(':')) {
+                    clause.directives[key[0..-2].trim()] = value
+                } else {
+                    clause.attributes[key] = value
+                }
+            }
+
+            if (clause.names || clause.attributes || clause.directives) result << clause
+            if (del != (',' as char)) break
+        }
+        result
+    }
+}

--- a/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/PomReader.groovy
@@ -101,34 +101,35 @@ class PomReader {
 
     private GPathResult slurpBestMatchPomFromZip(ResolvedArtifact artifact) {
         File archiveToSearch = artifact.file
-        ZipFile archive = new ZipFile(archiveToSearch, ZipFile.OPEN_READ)
-        List<ZipEntry> pomEntries = archive.entries().toList().<ZipEntry>findAll { ZipEntry entry ->
-            entry.name.endsWith("pom.xml") || entry.name.endsWith(".pom")
-        }
-        LOGGER.debug("Searching for POM file in $archiveToSearch -- found ${pomEntries?.size()}")
-        if (!pomEntries) return null
-        try {
-            if (1 == pomEntries.size()) {
-                LOGGER.debug("Only one POM file was found in $archiveToSearch")
-                return createParser().parse(archive.getInputStream(pomEntries.first()))
+        try (ZipFile archive = new ZipFile(archiveToSearch, ZipFile.OPEN_READ)) {
+            List<ZipEntry> pomEntries = archive.entries().toList().<ZipEntry> findAll { ZipEntry entry ->
+                entry.name.endsWith("pom.xml") || entry.name.endsWith(".pom")
             }
-
-            for (final ZipEntry zipEntry in pomEntries) {
-                final GPathResult pom = createParser().parse(archive.getInputStream(zipEntry))
-
-                if (areArtifactAndPomGroupAndArtifactIdEqual(artifact, pom)) {
-                    LOGGER.debug("POM file in $archiveToSearch matched the artifact.")
-                    return pom
-                } else {
-                    LOGGER.debug("POM file in $archiveToSearch does not match the artifact, trying another one.")
+            LOGGER.debug("Searching for POM file in $archiveToSearch -- found ${pomEntries?.size()}")
+            if (!pomEntries) return null
+            try {
+                if (1 == pomEntries.size()) {
+                    LOGGER.debug("Only one POM file was found in $archiveToSearch")
+                    return createParser().parse(archive.getInputStream(pomEntries.first()))
                 }
+
+                for (final ZipEntry zipEntry in pomEntries) {
+                    final GPathResult pom = createParser().parse(archive.getInputStream(zipEntry))
+
+                    if (areArtifactAndPomGroupAndArtifactIdEqual(artifact, pom)) {
+                        LOGGER.debug("POM file in $archiveToSearch matched the artifact.")
+                        return pom
+                    } else {
+                        LOGGER.debug("POM file in $archiveToSearch does not match the artifact, trying another one.")
+                    }
+                }
+            } catch (SAXException e) {
+                LOGGER.warn("Error parsing $pomEntries.name in $archiveToSearch", e)
+                return null
+            } catch (IOException e) {
+                LOGGER.warn("Error reading $pomEntries.name in $archiveToSearch", e)
+                return null
             }
-        } catch (SAXException e) {
-            LOGGER.warn("Error parsing $pomEntries.name in $archiveToSearch", e)
-            return null
-        } catch (IOException e) {
-            LOGGER.warn("Error reading $pomEntries.name in $archiveToSearch", e)
-            return null
         }
 
         return null

--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -17,8 +17,6 @@ package com.github.jk1.license.render
 
 import com.github.jk1.license.*
 import com.github.jk1.license.util.Files
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 
 class InventoryHtmlReportRenderer extends InventoryReportRenderer {
 
@@ -273,13 +271,12 @@ class InventoryHtmlReportRenderer extends InventoryReportRenderer {
         if (manifest.url && !projectUrlDone) {
             output << sectionLink("Manifest Project URL", manifest.url, manifest.url)
         }
-        if (manifest.license) {
-            if (Files.maybeLicenseUrl(manifest.licenseUrl)) {
-                output << section("Manifest License", "${manifest.license} - ${Files.maybeLicenseUrl(manifest.licenseUrl) ? link(manifest.licenseUrl, manifest.licenseUrl) : section("License", manifest.licenseUrl)}")
-            } else if (manifest.hasPackagedLicense) {
-                output << sectionLink("Packaged License File", manifest.license, manifest.url)
+        manifest.licenses.each { License license ->
+            if (!license.name) return
+            if (Files.isPackagedLicenseFile(config.absoluteOutputDir, license.url)) {
+                output << sectionLink("Packaged License File", license.name, license.url)
             } else {
-                output << section("Manifest License", "${manifest.license} (Not Packaged)")
+                output << section("Manifest License", license.name + (Files.maybeLicenseUrl(license.url) ? " - " + link(license.url, license.url) : ""))
             }
         }
     }
@@ -324,9 +321,4 @@ class InventoryHtmlReportRenderer extends InventoryReportRenderer {
     private GString sectionLink(String label, String name, String url) {
         section(label, link(name, url))
     }
-
-    private String safeGet(String[] arr, int index) {
-        arr.length > index ? arr[index] : null
-    }
-
 }

--- a/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
@@ -22,6 +22,7 @@ import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.PomData
 import com.github.jk1.license.ProjectData
+import com.github.jk1.license.util.Files
 
 class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
     private Boolean includeTimestamp
@@ -125,13 +126,14 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
         if (manifest.url && !projectUrlDone) {
             output << sectionLink("Manifest Project URL", manifest.url, manifest.url)
         }
-        if (manifest.license) {
-            if (manifest.license.startsWith("http")) {
-                output << sectionLink("Manifest license URL", manifest.license, manifest.license)
-            } else if (manifest.hasPackagedLicense) {
-                output << sectionLink("Packaged License File", manifest.license, manifest.url)
+        manifest.licenses.each { License license ->
+            if (!license.name) return
+            if (Files.isPackagedLicenseFile(config.absoluteOutputDir, license.url)) {
+                output << sectionLink("Packaged License File", license.name, license.url)
+            } else if (Files.maybeLicenseUrl(license.url)) {
+                output << sectionLink("Manifest License", license.name, license.url)
             } else {
-                output << section("Manifest License", "${manifest.license} (Not Packaged)")
+                output << section("Manifest License", license.name)
             }
         }
     }
@@ -176,10 +178,6 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
 
     private GString sectionLink(String label, String name, String url) {
         section(label, link(name, url))
-    }
-
-    private String safeGet(String[] arr, int index) {
-        arr.length > index ? arr[index] : null
     }
 
 }

--- a/src/main/groovy/com/github/jk1/license/render/InventoryReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryReportRenderer.groovy
@@ -86,9 +86,11 @@ class InventoryReportRenderer implements ReportRenderer {
             boolean anyLicense = false
 
             for (ManifestData manifestData : module.manifests) {
-                if (manifestData.license && Files.maybeLicenseUrl(manifestData.licenseUrl)) {
-                    anyLicense = true
-                    addModule(inventory, manifestData.license, module)
+                for (License license : manifestData.licenses) {
+                    if (license.name && Files.maybeLicenseUrl(license.url)) {
+                        anyLicense = true
+                        addModule(inventory, license.name, module)
+                    }
                 }
             }
 
@@ -212,13 +214,12 @@ class InventoryReportRenderer implements ReportRenderer {
         if (manifest.url && !projectUrlDone) {
             output << "  - Manifest Project URL:\n    - ${manifest.url}\n"
         }
-        if (manifest.license) {
-            if (manifest.license.startsWith("http")) {
-                output << "  - Manifest license URL:\n    - ${manifest.license}\n"
-            } else if (manifest.hasPackagedLicense) {
-                output << "  - Packaged License File:\n    - ${manifest.license}\n"
+        manifest.licenses.each { License license ->
+            if (!license.name) return
+            if (Files.isPackagedLicenseFile(config.absoluteOutputDir, license.url)) {
+                output << "  - Packaged License File:\n    - ${license.name}\n"
             } else {
-                output << "  - Manifest License:\n    - ${manifest.license} (Not Packaged)\n"
+                output << "  - Manifest License:\n    - ${Files.maybeLicenseUrl(license.url) ? license.url : license.name}\n"
             }
         }
     }
@@ -252,7 +253,8 @@ class InventoryReportRenderer implements ReportRenderer {
         output << "\n\n"
     }
 
-    private String safeGet(String[] arr, int index) {
+    @SuppressWarnings('GrMethodMayBeStatic')
+    protected String safeGet(String[] arr, int index) {
         arr.length > index ? arr[index] : null
     }
 

--- a/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/LicenseDataCollector.groovy
@@ -47,17 +47,17 @@ class LicenseDataCollector {
             if (manifest.url) {
                 info.moduleUrls << manifest.url
             }
-            if (manifest.license || manifest.licenseUrl) {
-                // merge manifest.license into info.licenses
-                License existing = info.licenses.find { it.name == manifest.license || it.url == manifest.licenseUrl }
-                if (existing &&
-                        (existing.name && (!manifest.license || existing.name == manifest.license)) &&
-                        (existing.url && (!manifest.licenseUrl || existing.url == manifest.licenseUrl))) {
-                    info.licenses.remove(existing)
+            manifest.licenses.each { manifestLicense ->
+                if (manifestLicense.name || manifestLicense.url) {
+                    License existing = info.licenses.find { it.name == manifestLicense.name || it.url == manifestLicense.url }
+                    if (existing &&
+                            (existing.name && (!manifestLicense.name || existing.name == manifestLicense.name)) &&
+                            (existing.url && (!manifestLicense.url || existing.url == manifestLicense.url))) {
+                        info.licenses.remove(existing)
+                    }
+                    info.licenses.add(
+                            new License(name: manifestLicense.name ?: existing?.name, url: manifestLicense.url ?: existing?.url))
                 }
-                info.licenses.add(
-                        new License(name: manifest.license ? manifest.license : (existing ? existing.name : null),
-                                url: manifest.licenseUrl ? manifest.licenseUrl : (existing ? existing.url : null)))
             }
         }
 

--- a/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
@@ -134,27 +134,28 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
                     "\n            </code>" +
                     "\n        </p>"
             }
-            if (manifest.license) {
-                if (Files.maybeLicenseUrl(manifest.licenseUrl)) {
-                    output << "" +
-                        "\n        <p>" +
-                        "\n            <strong>Manifest license URL:</strong>" +
-                        "\n            <a href=\"$manifest.licenseUrl\">" +
-                        "\n                $manifest.license" +
-                        "\n            </a>" +
-                        "\n        </p>"
-                } else if (manifest.hasPackagedLicense) {
+            manifest.licenses.each { License license ->
+                if (!license.name) return
+                if (Files.isPackagedLicenseFile(config.absoluteOutputDir, license.url)) {
                     output << "" +
                         "\n        <p>" +
                         "\n            <strong>Packaged License File:</strong>" +
-                        "\n            <a href=\"$manifest.url\">" +
-                        "\n                $manifest.license" +
+                        "\n            <a href=\"$license.url\">" +
+                        "\n                $license.name" +
+                        "\n            </a>" +
+                        "\n        </p>"
+                } else if (Files.maybeLicenseUrl(license.url)) {
+                    output << "" +
+                        "\n        <p>" +
+                        "\n            <strong>Manifest License:</strong>" +
+                        "\n            <a href=\"$license.url\">" +
+                        "\n                $license.name" +
                         "\n            </a>" +
                         "\n        </p>"
                 } else {
                     output << "" +
                         "\n        <p>" +
-                        "\n            <strong>Manifest License:</strong> $manifest.license (Not packaged)" +
+                        "\n            <strong>Manifest License:</strong> $license.name" +
                         "\n        </p>"
                 }
             }

--- a/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
@@ -26,7 +26,7 @@ import com.github.jk1.license.util.Files
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 
-class TextReportRenderer implements ReportRenderer{
+class TextReportRenderer implements ReportRenderer {
 
     private Project project
     private LicenseReportExtension config
@@ -91,13 +91,12 @@ This report was generated at ${new Date()}.
             if (manifest.url && !projectUrlDone) {
                 output << "Manifest Project URL: $manifest.url\n\n"
             }
-            if (manifest.license) {
-                if (Files.maybeLicenseUrl(manifest.licenseUrl)) {
-                    output << "Manifest license URL: $manifest.licenseUrl\n\n"
-                } else if (manifest.hasPackagedLicense) {
-                    output << "Packaged License File: $manifest.license\n\n"
+            manifest.licenses.each { License license ->
+                if (!license.name) return
+                if (Files.isPackagedLicenseFile(config.absoluteOutputDir, license.url)) {
+                    output << "Packaged License File: $license.name\n\n"
                 } else {
-                    output << "Manifest License: $manifest.license (Not packaged)\n\n"
+                    output << "Manifest License: ${license.name + (Files.maybeLicenseUrl(license.url) ? " - " + license.url : "")}\n\n"
                 }
             }
         }

--- a/src/main/groovy/com/github/jk1/license/util/Files.groovy
+++ b/src/main/groovy/com/github/jk1/license/util/Files.groovy
@@ -27,4 +27,8 @@ class Files {
     static boolean maybeLicenseUrl(String url) {
         return url != null && (url.startsWith("http:") || url.startsWith("https:"))
     }
+
+    static boolean isPackagedLicenseFile(String outputDir, String relativePath) {
+        return outputDir != null && relativePath != null && new File(outputDir, relativePath).isFile()
+    }
 }

--- a/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/AbstractGradleRunnerFunctionalSpec.groovy
@@ -68,7 +68,7 @@ abstract class AbstractGradleRunnerFunctionalSpec extends Specification {
     }
 
     static String prettyPrintJson(Object obj) {
-        new JsonBuilder(obj).toPrettyString()
+        new JsonBuilder(obj, RawProjectDataJsonRenderer.GENERATOR).toPrettyString()
     }
 
     static List<File> buildPluginClasspathWithTestClasspath() {

--- a/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
+++ b/src/test/groovy/com/github/jk1/license/ProjectBuilder.groovy
@@ -15,6 +15,7 @@
  */
 package com.github.jk1.license
 
+import com.github.jk1.license.render.RawProjectDataJsonRenderer
 import com.github.jk1.license.util.Files
 import groovy.json.JsonBuilder
 
@@ -151,7 +152,6 @@ class ProjectBuilder extends BuilderSupport {
             version: "dummy-mani-version",
             description: "dummy-mani-desc",
             vendor: "dummy-mani-vendor",
-            license: "Apache 2.0",
             url: url
         )
 
@@ -183,11 +183,8 @@ class ProjectBuilder extends BuilderSupport {
         } else if (current instanceof ManifestData) {
             if (license != null)
                 addManifestLicense(license)
-            else {
-                if (map['name'])
-                    current.license = map['name']
-                if (map['url'])
-                    current.licenseUrl = map['url']
+            else if (map['name'] || map['url']) {
+                ((ManifestData)current).licenses << new License(name: map['name'], url: map['url'])
             }
         } else {
             throw new IllegalAccessException("current must be PomData or ManifestData not $current")
@@ -220,22 +217,15 @@ class ProjectBuilder extends BuilderSupport {
     }
     
     private String addManifestLicense(Object license) {
-        ManifestData manifest = (ManifestData)current
-        String licenseText
-
+        def manifest = current as ManifestData
         if (license instanceof License) {
-            licenseText = ((License)license).name
+            manifest.licenses << license
+        } else if (license instanceof String && Files.maybeLicenseUrl(license)) {
+            manifest.licenses << new License(url: license)
         } else if (license instanceof String) {
-            licenseText = license.toString()
+            manifest.licenses << new License(name: license)
         } else {
             throw new IllegalArgumentException("license must be a License or a String but is $license")
-        }
-        if (Files.maybeLicenseUrl(licenseText)) {
-            manifest.license = null // initialized to "Apache 2.0" above
-            manifest.licenseUrl = licenseText
-        }
-        else {
-            manifest.license = licenseText
         }
     }
 
@@ -243,7 +233,6 @@ class ProjectBuilder extends BuilderSupport {
         license.name = map.name ?: license.name
         license.url = map.url ?: license.url
     }
-
 
     static License cloneLicense(License license) {
         new License(
@@ -253,8 +242,8 @@ class ProjectBuilder extends BuilderSupport {
     }
 
     static String json(ProjectData data) {
-        def configurationsString = new JsonBuilder(data.configurations).toPrettyString()
-        def importedModulesString = new JsonBuilder(data.importedModules).toPrettyString()
+        def configurationsString = new JsonBuilder(data.configurations, RawProjectDataJsonRenderer.GENERATOR).toPrettyString()
+        def importedModulesString = new JsonBuilder(data.importedModules, RawProjectDataJsonRenderer.GENERATOR).toPrettyString()
 
         """{
 "configurations": [
@@ -267,6 +256,6 @@ $configurationsString
     }
 
     static String json(Object data) {
-        new JsonBuilder(data).toPrettyString()
+        new JsonBuilder(data, RawProjectDataJsonRenderer.GENERATOR).toPrettyString()
     }
 }

--- a/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/filter/LicenseBundleNormalizerSpec.groovy
@@ -729,8 +729,6 @@ class LicenseBundleNormalizerSpec extends Specification {
                     module("mod1") {
                         manifest("mani1") {
                             license(name: "MIT License", url: "https://opensource.org/licenses/MIT")
-                        }
-                        manifest("mani1") {
                             license(name: "Apache License, Version 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }

--- a/src/test/groovy/com/github/jk1/license/reader/ExcludesFuncSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ExcludesFuncSpec.groovy
@@ -197,11 +197,12 @@ class ExcludesFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "javax.activation",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": "Sun Microsystems, Inc.",
                         "hasPackagedLicense": false,
                         "version": "1.1.1",
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": "Sun Java System Application Server"
@@ -250,11 +251,15 @@ class ExcludesFuncSpec extends AbstractGradleRunnerFunctionalSpec {
                 "group": "com.fasterxml.jackson.core",
                 "manifests": [
                     {
-                        "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "http://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "FasterXML",
                         "hasPackagedLicense": false,
                         "version": "2.12.3",
-                        "license": null,
                         "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
                         "url": "https://github.com/FasterXML/jackson-core",
                         "name": "Jackson-core"

--- a/src/test/groovy/com/github/jk1/license/reader/ManifestReaderTest.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ManifestReaderTest.groovy
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.reader
+
+import com.github.jk1.license.ManifestData
+import org.gradle.api.artifacts.ResolvedArtifact
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ManifestReaderTest extends Specification {
+
+    @TempDir
+    File tempDir
+
+    ManifestReader reader = new ManifestReader(null)
+
+    def "reads bundle attributes from a standalone .mf manifest file"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Example Bundle
+            Bundle-SymbolicName: com.example.bundle
+            Bundle-Version: 1.2.3
+            Bundle-Description: An example OSGi bundle
+            Bundle-Vendor: Example Inc.
+            Bundle-DocURL: https://example.com/docs
+            Bundle-License: Apache-2.0
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.name == "Example Bundle"
+        data.version == "1.2.3"
+        data.description == "An example OSGi bundle"
+        data.vendor == "Example Inc."
+        data.url == "https://example.com/docs"
+        data.licenses.size() == 1
+        data.licenses.first().name == "Apache-2.0"
+        data.licenses.first().url == null
+        !data.hasPackagedLicense
+    }
+
+    def "falls back to Implementation-Title and Implementation-Version when Bundle-* are missing"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Implementation-Title: Impl Title
+            Implementation-Version: 4.5.6
+            Implementation-Vendor: Impl Vendor
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.name == "Impl Title"
+        data.version == "4.5.6"
+        data.vendor == "Impl Vendor"
+    }
+
+    def "falls back to Bundle-SymbolicName and Specification-Version as last resort"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-SymbolicName: com.example.symbolic
+            Specification-Version: 7.8.9
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.name == "com.example.symbolic"
+        data.version == "7.8.9"
+    }
+
+    def "prefers Bundle-* attributes over Implementation-* fallbacks"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Bundle Name
+            Implementation-Title: Impl Title
+            Bundle-Version: 1.0.0
+            Implementation-Version: 2.0.0
+            Bundle-Vendor: Bundle Vendor
+            Implementation-Vendor: Impl Vendor
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.name == "Bundle Name"
+        data.version == "1.0.0"
+        data.vendor == "Bundle Vendor"
+    }
+
+    def "parses Bundle-License URL with description parameter"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Licensed Bundle
+            Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt;description=Apache-2.0
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == "Apache-2.0"
+        data.licenses.first().url == "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    }
+
+    def "prefers link parameter as license url when both name and link are URLs"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Licensed Bundle
+            Bundle-License: https://canonical.example.com/license;link=https://example.com/license.txt
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == null
+        data.licenses.first().url == "https://example.com/license.txt"
+    }
+
+    def "uses link as license url and non-URL name as license identifier"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Licensed Bundle
+            Bundle-License: Apache-2.0;link=https://www.apache.org/licenses/LICENSE-2.0.txt
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == "Apache-2.0"
+        data.licenses.first().url == "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    }
+
+    def "falls back to name when link parameter is not a URL"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Licensed Bundle
+            Bundle-License: https://www.apache.org/licenses/LICENSE-2.0.txt;link=not-a-url
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == null
+        data.licenses.first().url == "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    }
+
+    def "parses Bundle-License URL without a description parameter"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Licensed Bundle
+            Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == null
+        data.licenses.first().url == "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+
+    def "treats non-URL Bundle-License value as the license identifier"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Plain License Bundle
+            Bundle-License: MIT
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == "MIT"
+        data.licenses.first().url == null
+    }
+
+    def "returns null when the artifact file has no extension"() {
+        given:
+        File noExt = new File(tempDir, "MANIFEST")
+        noExt.text = "Manifest-Version: 1.0\n"
+
+        expect:
+        reader.readManifestData(artifactWith(noExt)) == null
+    }
+
+    def "returns null for unsupported file extensions"() {
+        given:
+        File txt = new File(tempDir, "something.txt")
+        txt.text = "Manifest-Version: 1.0\n"
+
+        expect:
+        reader.readManifestData(artifactWith(txt)) == null
+    }
+
+    def "treats commas inside quoted Bundle-License clauses as part of the value, not separators"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Dual
+            Bundle-License: "Apache License, Version 2.0";link="https://apache.org/license", "BSD 3-Clause";link="https://opensource.org/BSD-3-Clause"
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 2
+        data.licenses*.name.toSorted() == ["Apache License, Version 2.0", "BSD 3-Clause"]
+        data.licenses*.url.toSorted() == ["https://apache.org/license", "https://opensource.org/BSD-3-Clause"]
+    }
+
+    def "treats semicolons inside quoted Bundle-License values as part of the value, not parameter separators"() {
+        given:
+        File mf = manifestFile("""\
+            Manifest-Version: 1.0
+            Bundle-Name: Semi Quoted
+            Bundle-License: "Apache-2.0; with modifier";link="https://apache.org/license"
+            """.stripIndent())
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == "Apache-2.0; with modifier"
+        data.licenses.first().url == "https://apache.org/license"
+    }
+
+    def "ignores splitting of Bundle-License if things don't 'look right'"() {
+        given:
+        File mf = manifestFile("""\
+Manifest-Version: 1.0
+Bundle-Name: Non Quoted with semicolons; not strictly formatted
+Bundle-License: Apache License, Version 2.0; see: http://www.apache.or
+ g/licenses/LICENSE-2.0.txt
+""")
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.licenses.size() == 1
+        data.licenses.first().name == "Apache License, Version 2.0; see: http://www.apache.org/licenses/LICENSE-2.0.txt"
+        data.licenses.first().url == null
+    }
+
+    def "matches the .mf extension case-insensitively"() {
+        given:
+        File mf = new File(tempDir, "MANIFEST.MF")
+        mf.text = """\
+            Manifest-Version: 1.0
+            Bundle-Name: Mixed Case Extension
+            """.stripIndent()
+
+        when:
+        ManifestData data = reader.readManifestData(artifactWith(mf))
+
+        then:
+        data.name == "Mixed Case Extension"
+    }
+
+    private File manifestFile(String contents) {
+        File mf = new File(tempDir, "MANIFEST.mf")
+        mf.text = contents
+        return mf
+    }
+
+    private ResolvedArtifact artifactWith(File file) {
+        ResolvedArtifact artifact = Mock()
+        artifact.getFile() >> file
+        return artifact
+    }
+}

--- a/src/test/groovy/com/github/jk1/license/render/RawProjectDataJsonRenderer.groovy
+++ b/src/test/groovy/com/github/jk1/license/render/RawProjectDataJsonRenderer.groovy
@@ -16,11 +16,32 @@
 package com.github.jk1.license.render
 
 import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ManifestData
 import com.github.jk1.license.ProjectData
 import groovy.json.JsonBuilder
+import groovy.json.JsonGenerator
 
 class RawProjectDataJsonRenderer implements ReportRenderer {
     static final String RAW_PROJECT_JSON_NAME = "raw-project-data.json"
+
+    /**
+     * Type-aware generator that omits the deprecated {@code license}/{@code licenseUrl} read-only
+     * views from {@link ManifestData} when serializing to JSON. The same fields on
+     * {@code LicenseFileDetails} are unaffected because the converter is scoped to ManifestData.
+     */
+    static final JsonGenerator GENERATOR = new JsonGenerator.Options()
+            .addConverter(ManifestData) { ManifestData m, String key ->
+                [
+                    licenses          : m.licenses,
+                    vendor            : m.vendor,
+                    hasPackagedLicense: m.hasPackagedLicense,
+                    version           : m.version,
+                    description       : m.description,
+                    url               : m.url,
+                    name              : m.name,
+                ]
+            }
+            .build()
 
     @Override
     void render(ProjectData data) {
@@ -31,7 +52,7 @@ class RawProjectDataJsonRenderer implements ReportRenderer {
         def project = data.project
         data.project = null
 
-        def json = new JsonBuilder(data).toPrettyString()
+        def json = new JsonBuilder(data, GENERATOR).toPrettyString()
         outputFile << json
 
         data.project = project

--- a/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[0].json
+++ b/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[0].json
@@ -4,7 +4,6 @@
             "moduleName": "org.ehcache:ehcache",
             "moduleVersion": "3.3.1",
             "moduleUrls": [
-                "ehcache-3.3.1.jar/LICENSE.html",
                 "http://ehcache.org"
             ],
             "moduleLicenses": [
@@ -14,7 +13,7 @@
                 },
                 {
                     "moduleLicense": "LICENSE",
-                    "moduleLicenseUrl": null
+                    "moduleLicenseUrl": "ehcache-3.3.1.jar/LICENSE.html"
                 }
             ]
         },

--- a/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[1].json
+++ b/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[1].json
@@ -4,7 +4,6 @@
             "moduleName": "org.ehcache:ehcache",
             "moduleVersion": "3.3.1",
             "moduleUrls": [
-                "ehcache-3.3.1.jar/LICENSE.html",
                 "http://ehcache.org"
             ],
             "moduleLicenses": [
@@ -14,7 +13,7 @@
                 },
                 {
                     "moduleLicense": "LICENSE",
-                    "moduleLicenseUrl": null
+                    "moduleLicenseUrl": "ehcache-3.3.1.jar/LICENSE.html"
                 }
             ]
         },

--- a/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[2].json
+++ b/src/test/resources/com/github/jk1/license/PluginSpec/run_plugin_with_gradle__gradle_version-[2].json
@@ -4,7 +4,6 @@
             "moduleName": "org.ehcache:ehcache",
             "moduleVersion": "3.3.1",
             "moduleUrls": [
-                "ehcache-3.3.1.jar/LICENSE.html",
                 "http://ehcache.org"
             ],
             "moduleLicenses": [
@@ -14,7 +13,7 @@
                 },
                 {
                     "moduleLicense": "LICENSE",
-                    "moduleLicenseUrl": null
+                    "moduleLicenseUrl": "ehcache-3.3.1.jar/LICENSE.html"
                 }
             ]
         },

--- a/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/different_configurations_are_kept.json
+++ b/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/different_configurations_are_kept.json
@@ -5,11 +5,15 @@
                 "group": "org.apache.commons",
                 "manifests": [
                     {
-                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -63,11 +67,15 @@
                 "group": "org.apache.commons",
                 "manifests": [
                     {
-                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"

--- a/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/project_filtering_is_respected.json
+++ b/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/project_filtering_is_respected.json
@@ -5,11 +5,15 @@
                 "group": "org.apache.commons",
                 "manifests": [
                     {
-                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"

--- a/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/repositories_of_the_sub_projects_are_used.json
+++ b/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/repositories_of_the_sub_projects_are_used.json
@@ -5,11 +5,12 @@
                 "group": "org.jetbrains",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": null

--- a/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/same_dependencies_of_the_same_configuration_are_merged.json
+++ b/src/test/resources/com/github/jk1/license/reader/MultiProjectReaderFuncSpec/same_dependencies_of_the_same_configuration_are_merged.json
@@ -5,11 +5,15 @@
                 "group": "org.apache.commons",
                 "manifests": [
                     {
-                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -42,11 +46,12 @@
                 "group": "org.jetbrains",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": null

--- a/src/test/resources/com/github/jk1/license/reader/ProjectReaderFuncSpec/it_reads_dependencies_correctly.json
+++ b/src/test/resources/com/github/jk1/license/reader/ProjectReaderFuncSpec/it_reads_dependencies_correctly.json
@@ -5,11 +5,12 @@
                 "group": "aopalliance",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": null
@@ -42,11 +43,12 @@
                 "group": "commons-logging",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": "Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "1.1.1",
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": "Jakarta Commons Logging"
@@ -95,11 +97,15 @@
                 "group": "org.apache.commons",
                 "manifests": [
                     {
-                        "licenseUrl": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                        "licenses": [
+                            {
+                                "url": "https://www.apache.org/licenses/LICENSE-2.0.txt",
+                                "name": null
+                            }
+                        ],
                         "vendor": "The Apache Software Foundation",
                         "hasPackagedLicense": false,
                         "version": "3.7.0",
-                        "license": null,
                         "description": "Apache Commons Lang, a package of Java utility classes for the  classes that are in java.lang's hierarchy, or are considered to be so  standard as to justify existence in java.lang.",
                         "url": "http://commons.apache.org/proper/commons-lang/",
                         "name": "Apache Commons Lang"
@@ -148,13 +154,17 @@
                 "group": "org.ehcache",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            {
+                                "url": "ehcache-3.3.1.jar/LICENSE.html",
+                                "name": "LICENSE"
+                            }
+                        ],
                         "vendor": "Terracotta Inc., a wholly-owned subsidiary of Software AG USA, Inc.",
                         "hasPackagedLicense": true,
                         "version": "3.3.1",
-                        "license": "LICENSE",
                         "description": "Ehcache is an open-source caching library, compliant with the JSR-107 standard.",
-                        "url": "ehcache-3.3.1.jar/LICENSE.html",
+                        "url": "http://ehcache.org",
                         "name": "ehcache 3"
                     }
                 ],
@@ -201,11 +211,12 @@
                 "group": "org.slf4j",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": "SLF4J.ORG",
                         "hasPackagedLicense": false,
                         "version": "1.7.7",
-                        "license": null,
                         "description": "The slf4j API",
                         "url": null,
                         "name": "slf4j-api"
@@ -241,11 +252,12 @@
                 "group": "org.springframework",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": "spring-beans"
@@ -294,11 +306,12 @@
                 "group": "org.springframework",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": "spring-core"
@@ -347,11 +360,12 @@
                 "group": "org.springframework",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": "3.2.3.RELEASE",
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": "spring-tx"

--- a/src/test/resources/com/github/jk1/license/reader/ProjectReaderFuncSpec/it_reads_dependencies_with_variants_correctly.json
+++ b/src/test/resources/com/github/jk1/license/reader/ProjectReaderFuncSpec/it_reads_dependencies_with_variants_correctly.json
@@ -5,11 +5,12 @@
                 "group": "org.openjfx",
                 "manifests": [
                     {
-                        "licenseUrl": null,
+                        "licenses": [
+                            
+                        ],
                         "vendor": null,
                         "hasPackagedLicense": false,
                         "version": null,
-                        "license": null,
                         "description": null,
                         "url": null,
                         "name": null

--- a/src/test/resources/com/github/jk1/license/render/InventoryHtmlReportRendererSpec/check_the_correct_generation_of_html.html
+++ b/src/test/resources/com/github/jk1/license/render/InventoryHtmlReportRendererSpec/check_the_correct_generation_of_html.html
@@ -144,7 +144,7 @@
 <p><strong> 1.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod1 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
 <div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
 <label>Manifest License</label>
-<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<div class='dependency-value'>Apache 2.0</div>
 <label>POM Project URL</label>
 <div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
 <label>POM License</label>
@@ -162,7 +162,7 @@
 <p><strong> 3.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod4 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
 <div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
 <label>Manifest License</label>
-<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<div class='dependency-value'>Apache 2.0</div>
 <label>POM Project URL</label>
 <div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
 <label>POM License</label>
@@ -176,7 +176,7 @@
 <p><strong> 4.</strong> <strong>Group:</strong> dummy-group <strong>Name:</strong> mod4 <strong>Version:</strong> 0.0.1 </p><label>Manifest Project URL</label>
 <div class='dependency-value'><a href='http://dummy-mani-url'>http://dummy-mani-url</a></div>
 <label>Manifest License</label>
-<div class='dependency-value'>Apache 2.0 (Not Packaged)</div>
+<div class='dependency-value'>Apache 2.0</div>
 <label>POM Project URL</label>
 <div class='dependency-value'><a href='http://dummy-pom-project-url'>http://dummy-pom-project-url</a></div>
 <label>POM License</label>

--- a/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown.md
+++ b/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown.md
@@ -6,7 +6,7 @@ DATE
 
 **1** **Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)
@@ -17,7 +17,7 @@ DATE
 
 **3** **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)
@@ -26,7 +26,7 @@ DATE
 
 **4** **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)

--- a/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown_without_timestamp_and_counter.md
+++ b/src/test/resources/com/github/jk1/license/render/InventoryMarkdownReportRendererSpec/check_the_correct_generation_of_markdown_without_timestamp_and_counter.md
@@ -5,7 +5,7 @@
 
 **Group:** `dummy-group` **Name:** `mod1` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)
@@ -16,7 +16,7 @@
 
 **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)
@@ -25,7 +25,7 @@
 
 **Group:** `dummy-group` **Name:** `mod4` **Version:** `0.0.1` 
 > - **Manifest Project URL**: [http://dummy-mani-url](http://dummy-mani-url)
-> - **Manifest License**: Apache 2.0 (Not Packaged)
+> - **Manifest License**: Apache 2.0
 > - **POM Project URL**: [http://dummy-pom-project-url](http://dummy-pom-project-url)
 > - **POM License**: Apache License, Version 2.0 - [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 > - **Embedded license files**: [apache2.license](apache2.license)


### PR DESCRIPTION
OSGi bundles can model multiple licenses within a comma-delimited syntax; which the plugin currently does not handle correctly. Retains deprecated accessors for backward compatibility with anyone writing custom renderers.

Also tweaks the default renderers slightly for consistency; and avoids changing teh module project URL to point to a local license, which was incorrect.