### PR TITLE
fix: improve mappings for GNU classpath exception & MPL URLs with trailing slash

### DIFF
--- a/src/main/resources/default-license-normalizer-bundle.json
+++ b/src/main/resources/default-license-normalizer-bundle.json
@@ -78,6 +78,7 @@
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GNU General Public License, version 2.*cp?e" },
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GPL2 w/ CPE" },
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GPL-2\\.0 WITH Classpath-Exception-2\\.0" },
+    { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseUrlPattern" : ".*(www\\.)gnu\\.org/software/classpath/license.html" },
     { "bundleName" : "GPL-3.0-only", "licenseNamePattern" : ".*GNU GENERAL PUBLIC LICENSE.*3.*" },
     { "bundleName" : "GPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/GPL-3\\.0" },
     { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : ".*GNU LESSER GENERAL PUBLIC LICENSE.*2\\.1.*" },
@@ -96,9 +97,10 @@
     { "bundleName" : "MIT-0", "licenseNamePattern" : "(The\\s)?MIT No Attribution(\\slicen[cs]e)?(\\s\\(MIT[-]?0\\))?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : ".*Mozilla Public License.*1\\.1.*" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
+    { "bundleName" : "MPL-1.1", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/.*MPL/1\\.1/?" },
     { "bundleName" : "MPL-2.0", "licenseNamePattern" : ".*Mozilla Public License.*2\\.*" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MPL-2\\.0" },
-    { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/MPL/2\\.0/" },
+    { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/.*MPL/2\\.0/?" },
     { "bundleName" : "Public-Domain", "licenseNamePattern" : "((public)\\s(domain)).*", "transformUrl" : false },
     { "bundleName" : "Public-Domain", "licenseFileContentPattern" : ".*((Public)\\s(Domain)).*", "transformUrl" : false }
   ]

--- a/src/main/resources/spdx-license-normalizer-bundle.json
+++ b/src/main/resources/spdx-license-normalizer-bundle.json
@@ -77,6 +77,7 @@
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GNU General Public License, version 2.*cp?e" },
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GPL2 w/ CPE" },
     { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseNamePattern" : "GPL-2\\.0 WITH Classpath-Exception-2\\.0" },
+    { "bundleName" : "GPL-2.0-only WITH Classpath-exception-2.0", "licenseUrlPattern" : ".*(www\\.)gnu\\.org/software/classpath/license.html" },
     { "bundleName" : "GPL-3.0-only", "licenseNamePattern" : ".*GNU GENERAL PUBLIC LICENSE.*3.*" },
     { "bundleName" : "GPL-3.0-only", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/GPL-3\\.0" },
     { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : ".*GNU LESSER GENERAL PUBLIC LICENSE.*2\\.1.*" },
@@ -95,8 +96,9 @@
     { "bundleName" : "MIT-0", "licenseNamePattern" : "(The\\s)?MIT No Attribution(\\slicen[cs]e)?(\\s\\(MIT[-]?0\\))?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : ".*Mozilla Public License.*1\\.1.*" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
+    { "bundleName" : "MPL-1.1", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/.*MPL/1\\.1/?" },
     { "bundleName" : "MPL-2.0", "licenseNamePattern" : ".*Mozilla Public License.*2\\.*" },
     { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)?opensource\\.org/licenses/MPL-2\\.0" },
-    { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/MPL/2\\.0/" }
+    { "bundleName" : "MPL-2.0", "licenseUrlPattern" : ".*(www\\.)mozilla\\.org/.*MPL/2\\.0/?" }
   ]
 }


### PR DESCRIPTION
Basic mapping tweaks found from manifests in the wild.