### PR TITLE
fix: improve performance of ReportTask/CheckLicense on projects with many modules

### DIFF
--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -30,7 +30,6 @@ class LicenseReportExtension {
 
     public static final String[] ALL = []
 
-    public boolean unionParentPomLicenses
     public String outputDir
     public Project[] projects
     public Project[] buildScriptProjects
@@ -42,6 +41,7 @@ class LicenseReportExtension {
     public boolean excludeBoms
     public String[] excludeGroups
     public String[] excludes
+    public boolean unionParentPomLicenses
     public Object allowedLicensesFile
 
     LicenseReportExtension(Project project) {
@@ -97,17 +97,19 @@ class LicenseReportExtension {
         snapshot << 'filters'
         snapshot += filters.collect { it.class.name }
         snapshot << 'configurations '
-        snapshot += configurations
+        snapshot += configurations?.collect()
         snapshot << 'excludeOwnGroup'
-        snapshot += excludeOwnGroup
+        snapshot += String.valueOf(excludeOwnGroup)
         snapshot << 'excludeBoms'
-        snapshot += excludeBoms
+        snapshot += String.valueOf(excludeBoms)
         snapshot << 'exclude'
-        snapshot += excludeGroups
+        snapshot += excludeGroups?.collect()
         snapshot << 'excludes'
-        snapshot += excludes
+        snapshot += excludes?.collect()
         snapshot << 'unionParentPomLicenses'
-        snapshot += unionParentPomLicenses
+        snapshot += String.valueOf(unionParentPomLicenses)
+        snapshot << 'allowedLicensesFile'
+        snapshot += String.valueOf(allowedLicensesFile)
         snapshot.join("!")
     }
 

--- a/src/main/groovy/com/github/jk1/license/Model.groovy
+++ b/src/main/groovy/com/github/jk1/license/Model.groovy
@@ -20,7 +20,6 @@ import groovy.transform.Sortable
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
-import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.plugins.PluginContainer
 
 @Canonical
@@ -47,6 +46,9 @@ class ProjectData {
     List<ImportedModuleBundle> importedModules = new ArrayList<ImportedModuleBundle>()
     Set<ModuleData> getAllDependencies() {
         new TreeSet<ModuleData>(configurations*.dependencies.flatten() as List<ModuleData>)
+    }
+    def getExtension() {
+        project.getExtensions().findByType(LicenseReportExtension)
     }
 }
 

--- a/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
+++ b/src/main/groovy/com/github/jk1/license/filter/LicenseBundleNormalizer.groovy
@@ -45,7 +45,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
     protected String filterConfig = ""
     protected ReduceDuplicateLicensesFilter duplicateFilter = new ReduceDuplicateLicensesFilter()
     protected LicenseReportExtension config
-    protected  LicenseBundleNormalizerConfig normalizerConfig = new LicenseBundleNormalizerConfig(
+    protected LicenseBundleNormalizerConfig normalizerConfig = new LicenseBundleNormalizerConfig(
         bundles: new ArrayList<NormalizerLicenseBundle>(),
         transformationRules: new ArrayList<NormalizerTransformationRule>()
     )
@@ -93,8 +93,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
     private def applyBundleFrom(String text) {
         filterConfig += "normalizerText = $text\n"
         LOGGER.debug("Using supplied normalizer bundle: {}", text)
-        def config = toConfig(new JsonSlurper().setType(JsonParserType.LAX).parse(text.chars))
-        mergeConfigIntoGlobalConfig(config)
+        mergeConfigIntoGlobalConfig(toConfig(new JsonSlurper().setType(JsonParserType.LAX).parse(text.chars)))
     }
 
     @Input
@@ -104,7 +103,7 @@ class LicenseBundleNormalizer implements DependencyFilter {
     ProjectData filter(ProjectData data) {
         init()
         LOGGER.debug("Performing module license normalization")
-        config = data.project.licenseReport
+        config = data.extension
 
         List<NormalizerTransformationRuleMatcher> transformationRuleMatchers = makeNormalizerTransformationRuleMatchers(normalizerConfig.transformationRules)
 
@@ -317,10 +316,10 @@ class LicenseBundleNormalizer implements DependencyFilter {
     }
 
     protected static def toConfig(Object slurpResult) {
-        def config = new LicenseBundleNormalizerConfig()
-        config.bundles = slurpResult.bundles.collect { new NormalizerLicenseBundle(it) }
-        config.transformationRules = slurpResult.transformationRules.collect { new NormalizerTransformationRule(it) }
-        config
+        def normalizerConfig = new LicenseBundleNormalizerConfig()
+        normalizerConfig.bundles = slurpResult.bundles.collect { new NormalizerLicenseBundle(it) }
+        normalizerConfig.transformationRules = slurpResult.transformationRules.collect { new NormalizerTransformationRule(it) }
+        normalizerConfig
     }
 
     /**

--- a/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ConfigurationReader.groovy
@@ -19,13 +19,10 @@ import com.github.jk1.license.ConfigurationData
 import com.github.jk1.license.GradleProject
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.task.ReportTask
-import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-
-import static com.github.jk1.license.reader.ProjectReader.isResolvable
 
 class ConfigurationReader {
     private Logger LOGGER = Logging.getLogger(ReportTask.class)
@@ -48,12 +45,7 @@ class ConfigurationReader {
         }
 
         LOGGER.info("Processing configuration [$configuration], configuration will be resolved")
-        configuration.resolvedConfiguration // force configuration resolution
-
-        Set<ResolvedDependency> dependencies = new TreeSet<ResolvedDependency>(new ResolvedDependencyComparator())
-        for (ResolvedDependency dependency : configuration.resolvedConfiguration.lenientConfiguration.getFirstLevelModuleDependencies()) {
-            collectDependencies(dependencies, dependency)
-        }
+        Set<ResolvedDependency> dependencies = readDependenciesOnly(configuration)
 
         LOGGER.info("Processing dependencies for configuration [$configuration]: " + dependencies.join(','))
         for (ResolvedDependency dependency : dependencies) {
@@ -61,6 +53,20 @@ class ConfigurationReader {
             data.dependencies.add(moduleReader.read(project, dependency))
         }
         return data
+    }
+
+    /**
+     * Returns the resolved dependencies in {@code configuration} (transitive, deduped,
+     * exclusion-filtered) — the same set {@link #read} processes. Cheap relative to
+     * {@link #read} because it skips POM, manifest, and license-file work; suitable
+     * for cache-key fingerprinting where the full {@link com.github.jk1.license.ModuleData} is unnecessary.
+     */
+    Set<ResolvedDependency> readDependenciesOnly(Configuration configuration) {
+        Set<ResolvedDependency> accumulator = new TreeSet<ResolvedDependency>(new ResolvedDependencyComparator())
+        for (ResolvedDependency dependency : configuration.resolvedConfiguration.lenientConfiguration.firstLevelModuleDependencies) {
+            collectDependencies(accumulator, dependency)
+        }
+        accumulator
     }
 
     private Set<ResolvedDependency> collectDependencies(Set<ResolvedDependency> accumulator,

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -18,6 +18,7 @@ package com.github.jk1.license.reader
 import com.github.jk1.license.ConfigurationData
 import com.github.jk1.license.GradleProject
 import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ModuleData
 import com.github.jk1.license.ProjectData
 import com.github.jk1.license.task.ReportTask
 import org.gradle.api.NamedDomainObjectSet
@@ -29,6 +30,7 @@ import org.gradle.api.logging.Logging
 class ProjectReader {
     private Logger LOGGER = Logging.getLogger(ReportTask.class)
 
+    Project root
     private GradleProject[] projects
     private GradleProject[] buildScriptProjects
     private String[] configurations
@@ -36,22 +38,50 @@ class ProjectReader {
     private ConfigurationReader configurationReader
 
     ProjectReader(LicenseReportExtension config) {
+        this.root = config.projects.first()
         this.projects = config.projects.collect { GradleProject.ofProject(it) }
         this.buildScriptProjects = config.buildScriptProjects.collect { GradleProject.ofScript(it) }
         this.configurations = config.configurations
         this.configurationReader = new ConfigurationReader(config, new CachedModuleReader(config))
     }
 
-    ProjectData read(Project project) {
-        ProjectData data = new ProjectData()
-        data.project = project
+    /**
+     * Reads every configured project and buildScript project, merging configurations
+     * with the same name within each group. The returned data's {@code project} field
+     * is set to {@code owner}; the configurations span all configured projects.
+     */
+    ProjectData readAllProjects() {
+        LOGGER.info("Processing dependencies for project ${root.name}")
+        ProjectData data = new ProjectData(project: root)
 
         LOGGER.info("Configured projects: ${projects.join(',')}")
-        data.configurations.addAll(readProjects(projects))
         LOGGER.info("Configured buildScript projects: ${buildScriptProjects.join(',')}")
-        data.configurations.addAll(readProjects(buildScriptProjects))
+
+        def configurationData = (projects.toList() + buildScriptProjects.toList())
+                .collectMany { GradleProject p -> readGradleProject(p) { Configuration c -> configurationReader.read(p, c) } }
+
+        data.configurations.addAll(mergeConfigurationsByName(configurationData))
 
         return data
+    }
+
+    /**
+     * Walks the same scanned configurations as {@link #readAllProjects()} but collects
+     * only resolved dependency coordinates ("group:name:version"), skipping POM,
+     * manifest, and license-file resolution. Suitable for cache-key fingerprinting,
+     * where the full {@link ModuleData} is unnecessary.
+     */
+    SortedSet<String> readAllDependencyKeysOnly() {
+        (projects.toList() + buildScriptProjects.toList())
+                .collectMany { readGradleProject(it) { Configuration c -> configurationReader.readDependenciesOnly(c) } }
+                .flatten()
+                .collect { "${it.moduleGroup}:${it.moduleName}:${it.moduleVersion}" } as TreeSet
+    }
+
+    private <T> List<T> readGradleProject(GradleProject project, Closure<T> configHandler) {
+        Set<Configuration> configurationsToScan = withExtendsFrom(findConfigurationsToScan(project))
+        LOGGER.info("Configurations(${project.name}): ${configurationsToScan.join(',')}")
+        configurationsToScan.collect(configHandler)
     }
 
     private NamedDomainObjectSet<Configuration> findConfigurationsToScan(GradleProject project) {
@@ -77,37 +107,11 @@ class ProjectReader {
         configurationsToScan + configurationsToScan.collectMany { it.extendsFrom.findAll { it.canBeResolved } }.toSet()
     }
 
-    private List<ConfigurationData> readConfigurationData(Collection<Configuration> configurationsToScan, GradleProject project) {
-        configurationsToScan.collect { config ->
-            LOGGER.info("Reading configuration: " + config)
-            configurationReader.read(project, config)
+    private static List<ConfigurationData> mergeConfigurationsByName(Collection<ConfigurationData> configData) {
+        configData.groupBy { it.name }.collect { name, configs ->
+            new ConfigurationData(name: name).tap {
+                dependencies.addAll(configs*.dependencies.flatten() as List<ModuleData>)
+            }
         }
-    }
-
-    private List<ConfigurationData> readProjects(GradleProject[] projectsToScan) {
-        List<ConfigurationData> readConfigurations = projectsToScan.collectMany { subProject ->
-            Set<Configuration> configurationsToScan = withExtendsFrom(findConfigurationsToScan(subProject))
-            LOGGER.info("Configurations(${subProject.name}): ${configurationsToScan.join(',')}")
-            readConfigurationData(configurationsToScan, subProject)
-        }
-        mergeConfigurationDataWithSameName(readConfigurations)
-    }
-
-    private static List<ConfigurationData> mergeConfigurationDataWithSameName(Collection<ConfigurationData> configData) {
-        def configurationsByName = configData.groupBy { it.name }
-
-        configurationsByName.collect { _, configs ->
-            mergeConfigurations(configs)
-        }
-    }
-
-    private static ConfigurationData mergeConfigurations(Collection<ConfigurationData> configs) {
-        ConfigurationData merged = new ConfigurationData()
-
-        configs.forEach {
-            merged.name = it.name
-            merged.dependencies.addAll(it.dependencies)
-        }
-        merged
     }
 }

--- a/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/CsvReportRenderer.groovy
@@ -16,7 +16,6 @@
 package com.github.jk1.license.render
 
 import com.github.jk1.license.ImportedModuleData
-import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ModuleData
 import com.github.jk1.license.ProjectData
 import org.gradle.api.tasks.Input
@@ -68,8 +67,7 @@ class CsvReportRenderer implements ReportRenderer {
 
     @Override
     void render(ProjectData data) {
-        LicenseReportExtension config = data.project.licenseReport
-        File output = new File(config.absoluteOutputDir, filename)
+        File output = new File(data.extension.absoluteOutputDir, filename)
         output.write('')
 
         if (includeHeaderLine) {

--- a/src/main/groovy/com/github/jk1/license/render/ExtendedJsonReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/ExtendedJsonReportRenderer.groovy
@@ -112,7 +112,7 @@ class ExtendedJsonReportRenderer implements ReportRenderer {
 
     void render(ProjectData data) {
         project = data.project
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
 
         def jsonReport = [:]

--- a/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryHtmlReportRenderer.groovy
@@ -28,7 +28,7 @@ class InventoryHtmlReportRenderer extends InventoryReportRenderer {
     void render(ProjectData data) {
         project = data.project
         if( name == null ) name = project.name
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
         output.text = getHtmlStart()
         def inventory = buildLicenseInventory(data)

--- a/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/InventoryMarkdownReportRenderer.groovy
@@ -39,7 +39,7 @@ class InventoryMarkdownReportRenderer extends InventoryReportRenderer {
     void render(ProjectData data) {
         project = data.project
         if( name == null ) name = project.name
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
         output.delete()
         def inventory = buildLicenseInventory(data)

--- a/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/JsonReportRenderer.groovy
@@ -111,7 +111,7 @@ class JsonReportRenderer implements ReportRenderer {
 
     void render(ProjectData data) {
         project = data.project
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
 
         def jsonReport = [:]

--- a/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/SimpleHtmlReportRenderer.groovy
@@ -43,7 +43,7 @@ class SimpleHtmlReportRenderer implements ReportRenderer {
 
     void render(ProjectData data) {
         project = data.project
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
         output.text = """
 <!DOCTYPE html>

--- a/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/TextReportRenderer.groovy
@@ -43,7 +43,7 @@ class TextReportRenderer implements ReportRenderer {
 
     void render(ProjectData data) {
         project = data.project
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
         output.text = """
 Dependency License Report for $project.name ${if (!'unspecified'.equals(project.version)) project.version else ''}

--- a/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
+++ b/src/main/groovy/com/github/jk1/license/render/XmlReportRenderer.groovy
@@ -67,7 +67,7 @@ class XmlReportRenderer implements ReportRenderer {
 
     void render(ProjectData data) {
         project = data.project
-        config = project.licenseReport
+        config = data.extension
         output = new File(config.absoluteOutputDir, fileName)
         output.text = '<?xml version="1.0" encoding="UTF-8"?>\n'
         output << '<!DOCTYPE topic SYSTEM "' + schemaBaseUrl + 'html-entities.dtd">\n'

--- a/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
+++ b/src/main/groovy/com/github/jk1/license/task/ReportTask.groovy
@@ -19,7 +19,6 @@ import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.ProjectData
 import com.github.jk1.license.reader.ProjectReader
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.*
@@ -45,23 +44,17 @@ class ReportTask extends DefaultTask {
 
     @Input
     String[] getResolvedDependencies() {
-        def reader = new ProjectReader(config)
-        // Use resolved dependencies (including transitives) for cache key to ensure
-        // the cache is invalidated when any dependency changes, not just declared ones.
-        def deps = getConfig().projects
-                .collectMany { reader.read(it).allDependencies }
-                .collect { "${it.group}:${it.name}:${it.version}" }
-                .unique()
-                .sort()
-        deps
+        // Walks the same scanned configurations as the task action but skips POM,
+        // manifest, and license-file reads — only GAV coordinates are needed for the
+        // cache key. Any dependency change the report would surface invalidates the
+        // cache; everything else is wasted work at fingerprinting time.
+        new ProjectReader(config).readAllDependencyKeysOnly() as String[]
     }
 
     @TaskAction
     void generateReport() {
-        def project = config.projects.first()
-        LOGGER.info("Processing dependencies for project ${project.name}")
         new File(config.absoluteOutputDir).mkdirs()
-        ProjectData data = new ProjectReader(config).read(project)
+        ProjectData data = new ProjectReader(config).readAllProjects()
         LOGGER.info("Importing external dependency data. A total of ${config.importers.length} configured.")
         config.importers.each {
             data.importedModules.addAll(it.doImport())
@@ -70,10 +63,10 @@ class ReportTask extends DefaultTask {
         config.filters.each {
             data = it.filter(data)
         }
-        LOGGER.info("Building report for project ${project.name}")
+        LOGGER.info("Building report for project ${data.project.name}")
         config.renderers.each {
             it.render(data)
         }
-        LOGGER.info("Dependency license report for project ${project.name} created in ${config.absoluteOutputDir}")
+        LOGGER.info("Dependency license report for project ${data.project.name} created in ${config.absoluteOutputDir}")
     }
 }

--- a/src/test/groovy/com/github/jk1/license/reader/ProjectReaderSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/reader/ProjectReaderSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.jk1.license.reader
+
+import com.github.jk1.license.LicenseReportExtension
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class ProjectReaderSpec extends Specification {
+
+    Project root
+    Project subA
+    Project subB
+    LicenseReportExtension config
+
+    def setup() {
+        root = ProjectBuilder.builder().withName("root").build()
+        subA = ProjectBuilder.builder().withParent(root).withName("subA").build()
+        subB = ProjectBuilder.builder().withParent(root).withName("subB").build()
+
+        subA.configurations.create("cfgA") {
+            it.canBeResolved = true
+            it.canBeConsumed = false
+        }
+        subB.configurations.create("cfgB") {
+            it.canBeResolved = true
+            it.canBeConsumed = false
+        }
+
+        config = new LicenseReportExtension(root)
+        config.projects = [root, subA, subB] as Project[]
+        config.configurations = []
+    }
+
+    def "readAllProjects() spans every configured project"() {
+        when:
+        def reader = new ProjectReader(config)
+        def data = reader.readAllProjects()
+
+        then:
+        data.project == root
+        data.configurations*.name as Set == ["cfgA", "cfgB"] as Set
+    }
+
+    def "readAllProjects() merges same-name configurations from different projects into one entry"() {
+        given:
+        subA.configurations.create("shared") { it.canBeResolved = true; it.canBeConsumed = false }
+        subB.configurations.create("shared") { it.canBeResolved = true; it.canBeConsumed = false }
+        config.configurations = ["shared"] as String[]
+
+        when:
+        def reader = new ProjectReader(config)
+        def data = reader.readAllProjects()
+
+        then:
+        data.configurations*.name == ["shared"]
+    }
+
+    def "resolvedDependencyKeys() returns a sorted set of GAV strings for the scanned configurations"() {
+        when:
+        def keys = new ProjectReader(config).readAllDependencyKeysOnly()
+
+        then:
+        // Empty configurations resolve to empty dependency sets.
+        keys instanceof SortedSet
+        keys.isEmpty()
+    }
+
+    def "resolvedDependencyKeys() walks the same scanned configurations as readAllProjects()"() {
+        // Pins the equivalence relied on for cache-key correctness: any GAV the report
+        // would surface must appear in the cache key, and vice versa.
+        when:
+        def reader = new ProjectReader(config)
+        def fromReport = reader.readAllProjects().allDependencies
+                .collect { "${it.group}:${it.name}:${it.version}".toString() } as Set
+        def fromCacheKey = new ProjectReader(config).readAllDependencyKeysOnly() as Set
+
+        then:
+        fromCacheKey == fromReport
+    }
+}


### PR DESCRIPTION
- fixes #394 

The changes in 53f9c37 and 3048739 accidentally ended up doing quadratic re-resolution of projects and dependencies before de-duplicating the data, while determining the `@Input` cache key.

This change fixes that, and further improves the cache key resolution to only resolve dependencies without processing their POMs, manifests etc. It also refactors the logic to be appropriately reused across `ProjectReader`/`ConfigurationReader` etc to reduce the chance of such issues and make it a little easier to refactor things towards safer project access (which this project currently does not do)